### PR TITLE
Made the `design_unit` node more like the specification

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -208,7 +208,7 @@ module.exports = grammar({
             ),
 
             design_unit: $ => prec.right(choice(
-                $._context_item,
+                seq(repeat1($._context_item), optional($._library_unit)),
                 $._library_unit,
 
                 // These are useful for language injection, e.g. Markdown

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -24,8 +24,28 @@
         "type": "CHOICE",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "_context_item"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_context_item"
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_library_unit"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
           },
           {
             "type": "SYMBOL",

--- a/test/corpus/specification_examples/architecture.vhd
+++ b/test/corpus/specification_examples/architecture.vhd
@@ -98,39 +98,33 @@ end architecture DataFlow;
     (library_clause
       (LIBRARY)
       (logical_name_list
-        (library_namespace))))
-  (design_unit
+        (library_namespace)))
     (use_clause
       (USE)
       (selected_name
         (library_namespace)
         (identifier)
-        (ALL))))
-  (design_unit
+        (ALL)))
     (library_clause
       (LIBRARY)
       (logical_name_list
-        (library_namespace))))
-  (design_unit
+        (library_namespace)))
     (use_clause
       (USE)
       (selected_name
         (library_namespace)
         (identifier)
-        (ALL))))
-  (design_unit
+        (ALL)))
     (library_clause
       (LIBRARY)
       (logical_name_list
-        (library_namespace))))
-  (design_unit
+        (library_namespace)))
     (use_clause
       (USE)
       (selected_name
         (library_namespace)
         (identifier)
-        (ALL))))
-  (design_unit
+        (ALL)))
     (entity_declaration
       (ENTITY)
       (identifier)


### PR DESCRIPTION
The `design_unit` node used to be too short, splitting the file into multiple small design units, instead of linking the declarations as the specification implies.
