### PR TITLE
Changed all the keywords to anonymous nodes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -249,7 +249,7 @@ module.exports = grammar({
             ),
 
             selected_name: $ => seq(
-                $._logical_name, repeat(seq(".", choice($._identifier, alias(alias($.ALL, "all"), "all"))))
+                $._logical_name, repeat(seq(".", choice($._identifier, alias($.ALL, "all"))))
             ),
 
         // Library Units
@@ -329,7 +329,7 @@ module.exports = grammar({
             ),
 
             architecture_definition: $ => seq(
-                alias(alias($.ARCHITECTURE, "architecture"), "architecture"), $._identifier, alias($.OF, "of"), $.name, $.architecture_head, $.concurrent_block, $.end_architecture, ";"
+                alias($.ARCHITECTURE, "architecture"), $._identifier, alias($.OF, "of"), $.name, $.architecture_head, $.concurrent_block, $.end_architecture, ";"
             ),
 
             architecture_head: $ => seq(
@@ -337,7 +337,7 @@ module.exports = grammar({
             ),
 
             end_architecture: $ => seq(
-                alias($.END, "end"), optional(alias(alias($.ARCHITECTURE, "architecture"), "architecture")), optional($._identifier)
+                alias($.END, "end"), optional(alias($.ARCHITECTURE, "architecture")), optional($._identifier)
             ),
 
             package_definition: $ => seq(
@@ -583,7 +583,7 @@ module.exports = grammar({
             ),
 
             alias_declaration: $ => seq(
-                alias(alias($.ALIAS, "alias"), "alias"), $._alias_designator, optional(seq(":", $.subtype_indication)), alias($.IS, "is"), $.name, ";"
+                alias($.ALIAS, "alias"), $._alias_designator, optional(seq(":", $.subtype_indication)), alias($.IS, "is"), $.name, ";"
             ),
 
             component_declaration: $ => seq(
@@ -609,7 +609,7 @@ module.exports = grammar({
             ),
 
             disconnection_specification: $ => seq(
-                alias($.DISCONNECT, "disconnect"), $.guarded_signal_specification, alias(alias($.AFTER, "after"), "after"), $._expression, ";"
+                alias($.DISCONNECT, "disconnect"), $.guarded_signal_specification, alias($.AFTER, "after"), $._expression, ";"
             ),
 
             group_template_declaration: $ => seq(
@@ -671,8 +671,8 @@ module.exports = grammar({
             ),
 
             array_type_definition: $ => choice(
-                seq(alias(alias($.ARRAY, "array"), "array"), "(", $.array_index_incomplete_type_list, ")", alias($.OF, "of"), $._incomplete_subtype_indication),
-                seq(alias(alias($.ARRAY, "array"), "array"), $.index_constraint, alias($.OF, "of"), $.subtype_indication)
+                seq(alias($.ARRAY, "array"), "(", $.array_index_incomplete_type_list, ")", alias($.OF, "of"), $._incomplete_subtype_indication),
+                seq(alias($.ARRAY, "array"), $.index_constraint, alias($.OF, "of"), $.subtype_indication)
             ),
 
             array_index_incomplete_type_list: $ => seq(
@@ -694,11 +694,11 @@ module.exports = grammar({
             ),
 
             access_type_definition: $ => seq(
-                alias(alias($.ACCESS, "access"), "access"), $.subtype_indication, optional($.generic_map_aspect)
+                alias($.ACCESS, "access"), $.subtype_indication, optional($.generic_map_aspect)
             ),
 
             access_incomplete_type_definition: $ => seq(
-                alias(alias($.ACCESS, "access"), "access"), $._incomplete_subtype_indication
+                alias($.ACCESS, "access"), $._incomplete_subtype_indication
             ),
 
             file_type_definition: $ => seq(
@@ -936,7 +936,7 @@ module.exports = grammar({
             ),
 
             assertion: $ => seq(
-                alias(alias($.ASSERT, "assert"), "assert"), $._expression, optional($.report_expression), optional($.severity_expression)
+                alias($.ASSERT, "assert"), $._expression, optional($.report_expression), optional($.severity_expression)
             ),
 
             report_expression: $ => seq(
@@ -1369,7 +1369,7 @@ module.exports = grammar({
                 $.identifier,
                 $.character_literal,
                 $.operator_symbol,
-                alias(alias($.ALL, "all"), "all")
+                alias($.ALL, "all")
             ),
 
             _literal: $ => choice(
@@ -1717,7 +1717,7 @@ module.exports = grammar({
             signal_list: $ => choice(
                 seq($.name, repeat(seq(",", $.name))),
                 alias($.OTHERS, "others"),
-                alias(alias($.ALL, "all"), "all")
+                alias($.ALL, "all")
             ),
 
             entity_specification: $ => seq(
@@ -1726,7 +1726,7 @@ module.exports = grammar({
 
             _entity_class: $ => choice(
                 alias($.ENTITY, "entity"),
-                alias(alias($.ARCHITECTURE, "architecture"), "architecture"),
+                alias($.ARCHITECTURE, "architecture"),
                 alias($.CONFIGURATION, "configuration"),
                 alias($.PROCEDURE, "procedure"),
                 alias($.FUNCTION, "function"),
@@ -1750,7 +1750,7 @@ module.exports = grammar({
             entity_name_list: $ => choice(
                 seq($.entity_designator, repeat(seq(",", $.entity_designator))),
                 alias($.OTHERS, "others"),
-                alias(alias($.ALL, "all"), "all")
+                alias($.ALL, "all")
             ),
 
             entity_designator: $ => seq(
@@ -1859,7 +1859,7 @@ module.exports = grammar({
             ),
 
             waveform_element: $ => seq(
-                $._expression, optional(seq(alias(alias($.AFTER, "after"), "after"), $._expression)),
+                $._expression, optional(seq(alias($.AFTER, "after"), $._expression)),
             ),
 
             force_mode: $ => choice(
@@ -1970,7 +1970,7 @@ module.exports = grammar({
             ),
 
             _process_sensitivity_list: $ => choice(
-                alias(alias($.ALL, "all"), "all"),
+                alias($.ALL, "all"),
                 $.sensitivity_list
             ),
 
@@ -1994,7 +1994,7 @@ module.exports = grammar({
             instantiation_list: $ => choice(
                 seq($._label, repeat(seq(",", $._label))),
                 alias($.OTHERS, "others"),
-                alias(alias($.ALL, "all"), "all")
+                alias($.ALL, "all")
             ),
 
             binding_indication: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -240,8 +240,8 @@ module.exports = grammar({
             ),
 
             _logical_name: $ => choice(
-                $.library_namespace,
-                $._identifier
+                field("library", $.library_namespace),
+                field("library", $._identifier)
             ),
 
             selected_name_list: $ => seq(
@@ -265,7 +265,7 @@ module.exports = grammar({
             ),
 
             entity_declaration: $ => seq(
-                alias($.ENTITY, "entity"), $._identifier, $.entity_head, optional($.entity_body), $.end_entity, ";"
+                alias($.ENTITY, "entity"), field("entity", $._identifier), $.entity_head, optional($.entity_body), $.end_entity, ";"
             ),
 
             entity_head: $ => seq(
@@ -281,11 +281,11 @@ module.exports = grammar({
             ),
 
             end_entity: $ => seq(
-                alias($.END, "end"), optional(alias($.ENTITY, "entity")), optional($._identifier)
+                alias($.END, "end"), optional(alias($.ENTITY, "entity")), optional(field("entity", $._identifier))
             ),
 
             configuration_declaration: $ => seq(
-                alias($.CONFIGURATION, "configuration"), $._identifier, alias($.OF, "of"), $.name, $.configuration_head, $.block_configuration, $.end_configuration, ";"
+                alias($.CONFIGURATION, "configuration"), field("configuration", $._identifier), alias($.OF, "of"), field("entity", $.name), $.configuration_head, $.block_configuration, $.end_configuration, ";"
             ),
 
             configuration_head: $ => seq(
@@ -293,11 +293,11 @@ module.exports = grammar({
             ),
 
             end_configuration: $ => seq(
-                alias($.END, "end"), optional(alias($.CONFIGURATION, "configuration")), optional($._identifier)
+                alias($.END, "end"), optional(alias($.CONFIGURATION, "configuration")), optional(field("configuration", $._identifier))
             ),
 
             package_declaration: $ => seq(
-                alias($.PACKAGE, "package"), $._identifier, $.package_declaration_body, $.end_package, ";"
+                alias($.PACKAGE, "package"), field("package", $._identifier), $.package_declaration_body, $.end_package, ";"
             ),
 
             package_declaration_body: $ => seq(
@@ -305,15 +305,15 @@ module.exports = grammar({
             ),
 
             end_package: $ => seq(
-                alias($.END, "end"), optional(alias($.PACKAGE, "package")), optional($._identifier)
+                alias($.END, "end"), optional(alias($.PACKAGE, "package")), optional(field("package", $._identifier))
             ),
 
             package_instantiation_declaration: $ => seq(
-                alias($.PACKAGE, "package"), $._identifier, alias($.IS, "is"), alias($.NEW, "new"), $.name, optional($.generic_map_aspect), ";"
+                alias($.PACKAGE, "package"), field("package", $._identifier), alias($.IS, "is"), alias($.NEW, "new"), $.name, optional($.generic_map_aspect), ";"
             ),
 
             interface_package_declaration: $ => seq(
-                alias($.PACKAGE, "package"), $._identifier, alias($.IS, "is"), alias($.NEW, "new"), $.name, $._interface_package_generic_map_aspect
+                alias($.PACKAGE, "package"), field("package", $._identifier), alias($.IS, "is"), alias($.NEW, "new"), $.name, $._interface_package_generic_map_aspect
             ),
 
             context_declaration: $ => seq(
@@ -329,7 +329,7 @@ module.exports = grammar({
             ),
 
             architecture_definition: $ => seq(
-                alias($.ARCHITECTURE, "architecture"), $._identifier, alias($.OF, "of"), $.name, $.architecture_head, $.concurrent_block, $.end_architecture, ";"
+                alias($.ARCHITECTURE, "architecture"), field("architecture", $._identifier), alias($.OF, "of"), field("entity", $.name), $.architecture_head, $.concurrent_block, $.end_architecture, ";"
             ),
 
             architecture_head: $ => seq(
@@ -337,11 +337,11 @@ module.exports = grammar({
             ),
 
             end_architecture: $ => seq(
-                alias($.END, "end"), optional(alias($.ARCHITECTURE, "architecture")), optional($._identifier)
+                alias($.END, "end"), optional(alias($.ARCHITECTURE, "architecture")), optional(field("architecture", $._identifier))
             ),
 
             package_definition: $ => seq(
-                alias($.PACKAGE, "package"), alias($.BODY, "body"), $._identifier, $.package_definition_body, $.end_package_body, ";"
+                alias($.PACKAGE, "package"), alias($.BODY, "body"), field("package", $._identifier), $.package_definition_body, $.end_package_body, ";"
             ),
 
             package_definition_body: $ => seq(
@@ -349,7 +349,7 @@ module.exports = grammar({
             ),
 
             end_package_body: $ => seq(
-                alias($.END, "end"), optional(seq(alias($.PACKAGE, "package"), alias($.BODY, "body"))), optional($._identifier)
+                alias($.END, "end"), optional(seq(alias($.PACKAGE, "package"), alias($.BODY, "body"))), optional(field("package", $._identifier))
             ),
 
         // Declaration Item Lists
@@ -526,23 +526,26 @@ module.exports = grammar({
             ),
 
             subprogram_end: $ => seq(
-                alias($.END, "end"), optional(choice(alias($.PROCEDURE, "procedure"), alias($.FUNCTION, "function"))), optional($._designator)
+                alias($.END, "end"), optional(choice(alias($.PROCEDURE, "procedure"), alias($.FUNCTION, "function"))), optional(field("function", $._designator))
             ),
 
             subprogram_instantiation_declaration: $ => seq(
-                choice(alias($.PROCEDURE, "procedure"), alias($.FUNCTION, "function")), $._designator, alias($.IS, "is"), alias($.NEW, "new"), $.name, optional($.signature), optional($.generic_map_aspect), ";"
+                choice(
+                    seq(alias($.PROCEDURE, "procedure"), field("procedure", $._designator)),
+                    seq(alias($.FUNCTION, "function"), field("function", $._designator))
+                ), alias($.IS, "is"), alias($.NEW, "new"), $.name, optional($.signature), optional($.generic_map_aspect), ";"
             ),
 
             type_declaration: $ => seq(
-                alias($.TYPE, "type"), $._identifier, optional(seq(alias($.IS, "is"), $._type_definition)), ";"
+                alias($.TYPE, "type"), field("type", $._identifier), optional(seq(alias($.IS, "is"), $._type_definition)), ";"
             ),
 
             subtype_declaration: $ => seq(
-                alias($.SUBTYPE, "subtype"), $._identifier, alias($.IS, "is"), $.subtype_indication, ";"
+                alias($.SUBTYPE, "subtype"), field("type", $._identifier), alias($.IS, "is"), $.subtype_indication, ";"
             ),
 
             mode_view_declaration: $ => seq(
-                alias($.VIEW, "view"), $._identifier, alias($.OF, "of"), $.subtype_indication, $.mode_view_body, $.end_view, ";"
+                alias($.VIEW, "view"), field("view", $._identifier), alias($.OF, "of"), $.subtype_indication, $.mode_view_body, $.end_view, ";"
             ),
 
             mode_view_body: $ => seq(
@@ -550,7 +553,7 @@ module.exports = grammar({
             ),
 
             end_view: $ => seq(
-                alias($.END, "end"), alias($.VIEW, "view"), optional($._identifier)
+                alias($.END, "end"), alias($.VIEW, "view"), optional(field("view", $._identifier))
             ),
 
             constant_declaration: $ => seq(
@@ -587,7 +590,7 @@ module.exports = grammar({
             ),
 
             component_declaration: $ => seq(
-                alias($.COMPONENT, "component"), $._identifier, optional($.component_body), $.end_component, ";"
+                alias($.COMPONENT, "component"), field("component", $._identifier), optional($.component_body), $.end_component, ";"
             ),
 
             component_body: $ => choice(
@@ -597,11 +600,11 @@ module.exports = grammar({
             ),
 
             end_component: $ => seq(
-                alias($.END, "end"), optional(alias($.COMPONENT, "component")), optional($._identifier)
+                alias($.END, "end"), optional(alias($.COMPONENT, "component")), optional(field("component", $._identifier))
             ),
 
             attribute_declaration: $ => seq(
-                alias($.ATTRIBUTE, "attribute"), $._identifier, ":", $.name, ";"
+                alias($.ATTRIBUTE, "attribute"), field("attribute", $._identifier), ":", field("type", $.name), ";"
             ),
 
             attribute_specification: $ => seq(
@@ -635,7 +638,7 @@ module.exports = grammar({
             ),
 
             interface_type_declaration: $ => seq(
-                alias($.TYPE, "type"), $._identifier, optional(seq(alias($.IS, "is"), $._incomplete_type_definition))
+                alias($.TYPE, "type"), field("type", $._identifier), optional(seq(alias($.IS, "is"), $._incomplete_type_definition))
             ),
 
             _incomplete_type_definition: $ => choice(
@@ -690,7 +693,7 @@ module.exports = grammar({
             )),
 
             index_subtype_definition: $ => seq(
-                $.name, alias($.RANGE, "range"), alias($.box, "<>")
+                field("type", $.name), alias($.RANGE, "range"), alias($.box, "<>")
             ),
 
             access_type_definition: $ => seq(
@@ -702,15 +705,15 @@ module.exports = grammar({
             ),
 
             file_type_definition: $ => seq(
-                alias($.FILE, "file"), alias($.OF, "of"), $.name
+                alias($.FILE, "file"), alias($.OF, "of"), field("type", $.name)
             ),
 
             file_incomplete_type_definition: $ => seq(
-                alias($.FILE, "file"), alias($.OF, "of"), $.incomplete_type_mark
+                alias($.FILE, "file"), alias($.OF, "of"), $._incomplete_type_mark
             ),
 
             subtype_indication: $ => seq(
-                optional($.resolution_indication), $.name, optional($.range_constraint)
+                optional($.resolution_indication), field("type", $.name), optional($.range_constraint)
             ),
 
             resolution_indication: $ => choice(
@@ -736,8 +739,8 @@ module.exports = grammar({
                 $.unspecified_type_indication
             ),
 
-            incomplete_type_mark: $ => choice(
-                $.name,
+            _incomplete_type_mark: $ => choice(
+                field("type", $.name),
                 $.unspecified_type_indication
             ),
 
@@ -869,13 +872,9 @@ module.exports = grammar({
             ),
 
             instantiated_unit: $ => choice(
-                seq(alias($.COMPONENT, "component"), $.name), // Optional "component" covered by procedure call
-                seq(alias($.ENTITY, "entity"), optional(seq($.library_namespace, ".")), $.name, optional($.architecture_identifier)),
-                seq(alias($.CONFIGURATION, "configuration"), $.name)
-            ),
-
-            architecture_identifier: $ => seq(
-                "(", $._identifier, ")"
+                seq(alias($.COMPONENT, "component"), field("component", $.name)), // Optional "component" covered by procedure call
+                seq(alias($.ENTITY, "entity"), optional(seq(field("library", $.library_namespace), ".")), field("entity", $.name), optional(seq("(", field("architecture", $._identifier), ")"))),
+                seq(alias($.CONFIGURATION, "configuration"), field("configuration", $.name))
             ),
 
             process_statement: $ => seq(
@@ -1213,7 +1212,7 @@ module.exports = grammar({
             ),
 
             name: $ => prec.left(21, seq(
-                seq($._direct_name, repeat($.name_selector)),
+                seq($._direct_name, repeat($._name_selector)),
             )),
 
             _direct_name: $ => prec.left(choice(
@@ -1253,7 +1252,7 @@ module.exports = grammar({
                 $.library_type,
             ),
 
-            name_selector: $ => choice(
+            _name_selector: $ => choice(
                 $.function_call,
                 $.parenthesis_group,
                 $.attribute,
@@ -1344,21 +1343,21 @@ module.exports = grammar({
             ),
 
             _attribute_designator: $ => choice(
-                $._attribute,
-                $.attribute_function,
-                $.attribute_impure_function,
-                $.attribute_mode_view,
-                $.attribute_pure_function,
-                $.attribute_range,
-                $.attribute_signal,
-                $.attribute_subtype,
-                $.attribute_type,
-                $.attribute_value,
-                $.library_attribute
+                field("attribute", $._attribute),
+                field("attribute", $.attribute_function),
+                field("attribute", $.attribute_impure_function),
+                field("attribute", $.attribute_mode_view),
+                field("attribute", $.attribute_pure_function),
+                field("attribute", $.attribute_range),
+                field("attribute", $.attribute_signal),
+                field("attribute", $.attribute_subtype),
+                field("attribute", $.attribute_type),
+                field("attribute", $.attribute_value),
+                field("attribute", $.library_attribute)
             ),
 
             signature: $ => seq(
-                "[", optional(seq($.name, repeat(seq(",", $.name)))), optional(seq(alias($.RETURN, "return"), $.name)), "]"
+                "[", optional(seq(field("type", $.name), repeat(seq(",", field("type", $.name))))), optional(seq(alias($.RETURN, "return"), field("type", $.name))), "]"
             ),
 
             selection: $ => seq(
@@ -1373,7 +1372,7 @@ module.exports = grammar({
             ),
 
             _literal: $ => choice(
-                seq($._abstract_literal, optional($._unit)),
+                seq($._abstract_literal, optional(field("unit", $._unit))),
                 $.bit_string_literal,
                 $.string_literal,
                 $.string_literal_std_logic,
@@ -1582,19 +1581,19 @@ module.exports = grammar({
             ),
 
             procedure_specification: $ => prec.left(seq(
-                alias($.PROCEDURE, "procedure"), $._designator, optional($.subprogram_header), optional($.parameter_list_specification)
+                alias($.PROCEDURE, "procedure"), field("procedure", $._designator), optional($.subprogram_header), optional($.parameter_list_specification)
             )),
 
             interface_procedure_specification: $ => seq(
-                alias($.PROCEDURE, "procedure"), $._designator, optional($.parameter_list_specification)
+                alias($.PROCEDURE, "procedure"), field("procedure", $._designator), optional($.parameter_list_specification)
             ),
 
             function_specification: $ => seq(
-                optional(choice(alias($.PURE, "pure"), alias($.IMPURE, "impure"))), alias($.FUNCTION, "function"), $._designator, optional($.subprogram_header), optional($.parameter_list_specification), alias($.RETURN, "return"), optional(seq($._identifier, alias($.OF, "of"))), $.name
+                optional(choice(alias($.PURE, "pure"), alias($.IMPURE, "impure"))), alias($.FUNCTION, "function"), field("function", $._designator), optional($.subprogram_header), optional($.parameter_list_specification), alias($.RETURN, "return"), optional(seq($._identifier, alias($.OF, "of"))), field("type", $.name)
             ),
 
             interface_function_specification: $ => seq(
-                optional(choice(alias($.PURE, "pure"), alias($.IMPURE, "impure"))), alias($.FUNCTION, "function"), $._designator, optional($.parameter_list_specification), alias($.RETURN, "return"), $.name
+                optional(choice(alias($.PURE, "pure"), alias($.IMPURE, "impure"))), alias($.FUNCTION, "function"), field("function", $._designator), optional($.parameter_list_specification), alias($.RETURN, "return"), field("type", $.name)
             ),
 
             _interface_package_generic_map_aspect: $ => choice(
@@ -1652,11 +1651,11 @@ module.exports = grammar({
             ),
 
             record_mode_view_indication: $ => seq(
-                alias($.VIEW, "view"), $.name, optional(seq(alias($.OF, "of"), $.subtype_indication))
+                alias($.VIEW, "view"), field("view", $.name), optional(seq(alias($.OF, "of"), $.subtype_indication))
             ),
 
             array_mode_view_indication: $ => seq(
-                alias($.VIEW, "view"), "(", $.name, ")", optional(seq(alias($.OF, "of"), $.subtype_indication))
+                alias($.VIEW, "view"), "(", field("view", $.name), ")", optional(seq(alias($.OF, "of"), $.subtype_indication))
             ),
 
             mode_view_element_definition: $ => seq(
@@ -1678,11 +1677,11 @@ module.exports = grammar({
             ),
 
             element_record_mode_view_indication: $ => seq(
-                alias($.VIEW, "view"), $.name
+                alias($.VIEW, "view"), field("view", $.name)
             ),
 
             element_array_mode_view_indication: $ => seq(
-                alias($.VIEW, "view"), "(", $.name, ")"
+                alias($.VIEW, "view"), "(", field("view", $.name), ")"
             ),
 
             mode: $ => choice(
@@ -1711,7 +1710,7 @@ module.exports = grammar({
             ),
 
             guarded_signal_specification: $ => seq(
-                $.signal_list, ":", $.name
+                $.signal_list, ":", field("type", $.name)
             ),
 
             signal_list: $ => choice(
@@ -2002,8 +2001,8 @@ module.exports = grammar({
             ),
 
             entity_aspect: $ => choice(
-                seq(alias($.ENTITY, "entity"), $.name, optional(seq("(", $._identifier, ")"))),
-                seq(alias($.CONFIGURATION, "configuration"), $.name),
+                seq(alias($.ENTITY, "entity"), field("entity", $.name), optional(seq("(", field("architecture", $._identifier), ")"))),
+                seq(alias($.CONFIGURATION, "configuration"), field("configuration", $.name)),
                 $.OPEN
             ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -249,7 +249,7 @@ module.exports = grammar({
             ),
 
             selected_name: $ => seq(
-                $._logical_name, repeat(seq(".", choice($._identifier, alias($.ALL, "all"))))
+                $._logical_name, repeat(seq(".", choice($._identifier, $.ALL)))
             ),
 
         // Library Units
@@ -1332,7 +1332,7 @@ module.exports = grammar({
 
             _actual_part: $ => prec(21, choice(
                 seq(optional(alias($.INERTIAL, "inertial")), $.conditional_expression),
-                alias($.OPEN, "open")
+                $.OPEN
             )),
 
             attribute: $ => seq(
@@ -1369,7 +1369,7 @@ module.exports = grammar({
                 $.identifier,
                 $.character_literal,
                 $.operator_symbol,
-                alias($.ALL, "all")
+                $.ALL
             ),
 
             _literal: $ => choice(
@@ -1421,7 +1421,7 @@ module.exports = grammar({
             _element: $ => choice(
                 $.simple_expression,
                 $._range,
-                alias($.OTHERS, "others"),
+                $.OTHERS,
                 $.choices
             ),
 
@@ -1608,7 +1608,7 @@ module.exports = grammar({
             ),
 
             generic_map_default: $ => seq(
-                alias($.GENERIC, "generic"), alias($.MAP, "map"), "(", alias($.DEFAULT, "default"), ")"
+                alias($.GENERIC, "generic"), alias($.MAP, "map"), "(", $.DEFAULT, ")"
             ),
 
             generic_map_aspect: $ => seq(
@@ -1716,8 +1716,8 @@ module.exports = grammar({
 
             signal_list: $ => choice(
                 seq($.name, repeat(seq(",", $.name))),
-                alias($.OTHERS, "others"),
-                alias($.ALL, "all")
+                $.OTHERS,
+                $.ALL
             ),
 
             entity_specification: $ => seq(
@@ -1749,8 +1749,8 @@ module.exports = grammar({
 
             entity_name_list: $ => choice(
                 seq($.entity_designator, repeat(seq(",", $.entity_designator))),
-                alias($.OTHERS, "others"),
-                alias($.ALL, "all")
+                $.OTHERS,
+                $.ALL
             ),
 
             entity_designator: $ => seq(
@@ -1770,7 +1770,7 @@ module.exports = grammar({
             ),
 
             file_open_information: $ => seq(
-                optional(seq(alias($.OPEN, "open"), $._expression)), alias($.IS, "is"), $.file_logical_name
+                optional(seq($.OPEN, $._expression)), alias($.IS, "is"), $.file_logical_name
             ),
 
             file_logical_name: $ => $._expression,
@@ -1970,7 +1970,7 @@ module.exports = grammar({
             ),
 
             _process_sensitivity_list: $ => choice(
-                alias($.ALL, "all"),
+                $.ALL,
                 $.sensitivity_list
             ),
 
@@ -1993,8 +1993,8 @@ module.exports = grammar({
 
             instantiation_list: $ => choice(
                 seq($._label, repeat(seq(",", $._label))),
-                alias($.OTHERS, "others"),
-                alias($.ALL, "all")
+                $.OTHERS,
+                $.ALL
             ),
 
             binding_indication: $ => seq(
@@ -2004,7 +2004,7 @@ module.exports = grammar({
             entity_aspect: $ => choice(
                 seq(alias($.ENTITY, "entity"), $.name, optional(seq("(", $._identifier, ")"))),
                 seq(alias($.CONFIGURATION, "configuration"), $.name),
-                alias($.OPEN, "open")
+                $.OPEN
             ),
 
         // Comments

--- a/grammar.js
+++ b/grammar.js
@@ -224,15 +224,15 @@ module.exports = grammar({
             ),
 
             library_clause: $ => seq(
-                $.LIBRARY, $.logical_name_list, ";"
+                alias($.LIBRARY, "library"), $.logical_name_list, ";"
             ),
 
             use_clause: $ => seq(
-                $.USE, $.selected_name, repeat(seq(",", $.selected_name)), ";"
+                alias($.USE, "use"), $.selected_name, repeat(seq(",", $.selected_name)), ";"
             ),
 
             context_reference: $ => seq(
-                $.CONTEXT, $.selected_name_list, ";"
+                alias($.CONTEXT, "context"), $.selected_name_list, ";"
             ),
 
             logical_name_list: $ => seq(
@@ -249,7 +249,7 @@ module.exports = grammar({
             ),
 
             selected_name: $ => seq(
-                $._logical_name, repeat(seq(".", choice($._identifier, $.ALL)))
+                $._logical_name, repeat(seq(".", choice($._identifier, alias(alias($.ALL, "all"), "all"))))
             ),
 
         // Library Units
@@ -265,91 +265,91 @@ module.exports = grammar({
             ),
 
             entity_declaration: $ => seq(
-                $.ENTITY, $._identifier, $.entity_head, optional($.entity_body), $.end_entity, ";"
+                alias($.ENTITY, "entity"), $._identifier, $.entity_head, optional($.entity_body), $.end_entity, ";"
             ),
 
             entity_head: $ => seq(
-                $.IS, optional($.generic_clause), optional($.port_clause), repeat($._entity_declarative_item)
+                alias($.IS, "is"), optional($.generic_clause), optional($.port_clause), repeat($._entity_declarative_item)
             ),
 
             port_clause: $ => seq(
-                $.PORT, "(", $.interface_list, ")", ";"
+                alias($.PORT, "port"), "(", $.interface_list, ")", ";"
             ),
 
             entity_body: $ => seq(
-                $.BEGIN, repeat($._entity_statement)
+                alias($.BEGIN, "begin"), repeat($._entity_statement)
             ),
 
             end_entity: $ => seq(
-                $.END, optional($.ENTITY), optional($._identifier)
+                alias($.END, "end"), optional(alias($.ENTITY, "entity")), optional($._identifier)
             ),
 
             configuration_declaration: $ => seq(
-                $.CONFIGURATION, $._identifier, $.OF, $.name, $.configuration_head, $.block_configuration, $.end_configuration, ";"
+                alias($.CONFIGURATION, "configuration"), $._identifier, alias($.OF, "of"), $.name, $.configuration_head, $.block_configuration, $.end_configuration, ";"
             ),
 
             configuration_head: $ => seq(
-                $.IS, repeat($._configuration_declarative_item), repeat(seq($.verification_unit_binding_indication, ";"))
+                alias($.IS, "is"), repeat($._configuration_declarative_item), repeat(seq($.verification_unit_binding_indication, ";"))
             ),
 
             end_configuration: $ => seq(
-                $.END, optional($.CONFIGURATION), optional($._identifier)
+                alias($.END, "end"), optional(alias($.CONFIGURATION, "configuration")), optional($._identifier)
             ),
 
             package_declaration: $ => seq(
-                $.PACKAGE, $._identifier, $.package_declaration_body, $.end_package, ";"
+                alias($.PACKAGE, "package"), $._identifier, $.package_declaration_body, $.end_package, ";"
             ),
 
             package_declaration_body: $ => seq(
-                $.IS, optional($.package_header), repeat($._package_declarative_item)
+                alias($.IS, "is"), optional($.package_header), repeat($._package_declarative_item)
             ),
 
             end_package: $ => seq(
-                $.END, optional($.PACKAGE), optional($._identifier)
+                alias($.END, "end"), optional(alias($.PACKAGE, "package")), optional($._identifier)
             ),
 
             package_instantiation_declaration: $ => seq(
-                $.PACKAGE, $._identifier, $.IS, $.NEW, $.name, optional($.generic_map_aspect), ";"
+                alias($.PACKAGE, "package"), $._identifier, alias($.IS, "is"), alias($.NEW, "new"), $.name, optional($.generic_map_aspect), ";"
             ),
 
             interface_package_declaration: $ => seq(
-                $.PACKAGE, $._identifier, $.IS, $.NEW, $.name, $._interface_package_generic_map_aspect
+                alias($.PACKAGE, "package"), $._identifier, alias($.IS, "is"), alias($.NEW, "new"), $.name, $._interface_package_generic_map_aspect
             ),
 
             context_declaration: $ => seq(
-                $.CONTEXT, $._identifier, $.context_declaration_body, $.end_context, ";"
+                alias($.CONTEXT, "context"), $._identifier, $.context_declaration_body, $.end_context, ";"
             ),
 
             context_declaration_body: $ => seq(
-                $.IS, repeat($._context_item)
+                alias($.IS, "is"), repeat($._context_item)
             ),
 
             end_context: $ => seq(
-                $.END, optional($.CONTEXT), optional($._identifier)
+                alias($.END, "end"), optional(alias($.CONTEXT, "context")), optional($._identifier)
             ),
 
             architecture_definition: $ => seq(
-                $.ARCHITECTURE, $._identifier, $.OF, $.name, $.architecture_head, $.concurrent_block, $.end_architecture, ";"
+                alias(alias($.ARCHITECTURE, "architecture"), "architecture"), $._identifier, alias($.OF, "of"), $.name, $.architecture_head, $.concurrent_block, $.end_architecture, ";"
             ),
 
             architecture_head: $ => seq(
-                $.IS, repeat($._block_declarative_item)
+                alias($.IS, "is"), repeat($._block_declarative_item)
             ),
 
             end_architecture: $ => seq(
-                $.END, optional($.ARCHITECTURE), optional($._identifier)
+                alias($.END, "end"), optional(alias(alias($.ARCHITECTURE, "architecture"), "architecture")), optional($._identifier)
             ),
 
             package_definition: $ => seq(
-                $.PACKAGE, $.BODY, $._identifier, $.package_definition_body, $.end_package_body, ";"
+                alias($.PACKAGE, "package"), alias($.BODY, "body"), $._identifier, $.package_definition_body, $.end_package_body, ";"
             ),
 
             package_definition_body: $ => seq(
-                $.IS, repeat($._package_body_declarative_item)
+                alias($.IS, "is"), repeat($._package_body_declarative_item)
             ),
 
             end_package_body: $ => seq(
-                $.END, optional(seq($.PACKAGE, $.BODY)), optional($._identifier)
+                alias($.END, "end"), optional(seq(alias($.PACKAGE, "package"), alias($.BODY, "body"))), optional($._identifier)
             ),
 
         // Declaration Item Lists
@@ -522,52 +522,52 @@ module.exports = grammar({
             ),
 
             subprogram_head: $ => seq(
-                $.IS, repeat($._subprogram_declarative_item)
+                alias($.IS, "is"), repeat($._subprogram_declarative_item)
             ),
 
             subprogram_end: $ => seq(
-                $.END, optional(choice($.PROCEDURE, $.FUNCTION)), optional($._designator)
+                alias($.END, "end"), optional(choice(alias($.PROCEDURE, "procedure"), alias($.FUNCTION, "function"))), optional($._designator)
             ),
 
             subprogram_instantiation_declaration: $ => seq(
-                choice($.PROCEDURE, $.FUNCTION), $._designator, $.IS, $.NEW, $.name, optional($.signature), optional($.generic_map_aspect), ";"
+                choice(alias($.PROCEDURE, "procedure"), alias($.FUNCTION, "function")), $._designator, alias($.IS, "is"), alias($.NEW, "new"), $.name, optional($.signature), optional($.generic_map_aspect), ";"
             ),
 
             type_declaration: $ => seq(
-                $.TYPE, $._identifier, optional(seq($.IS, $._type_definition)), ";"
+                alias($.TYPE, "type"), $._identifier, optional(seq(alias($.IS, "is"), $._type_definition)), ";"
             ),
 
             subtype_declaration: $ => seq(
-                $.SUBTYPE, $._identifier, $.IS, $.subtype_indication, ";"
+                alias($.SUBTYPE, "subtype"), $._identifier, alias($.IS, "is"), $.subtype_indication, ";"
             ),
 
             mode_view_declaration: $ => seq(
-                $.VIEW, $._identifier, $.OF, $.subtype_indication, $.mode_view_body, $.end_view, ";"
+                alias($.VIEW, "view"), $._identifier, alias($.OF, "of"), $.subtype_indication, $.mode_view_body, $.end_view, ";"
             ),
 
             mode_view_body: $ => seq(
-                $.IS, repeat($.mode_view_element_definition)
+                alias($.IS, "is"), repeat($.mode_view_element_definition)
             ),
 
             end_view: $ => seq(
-                $.END, $.VIEW, optional($._identifier)
+                alias($.END, "end"), alias($.VIEW, "view"), optional($._identifier)
             ),
 
             constant_declaration: $ => seq(
-                $.CONSTANT, $.identifier_list, ":", $.subtype_indication, optional($.initialiser), ";"
+                alias($.CONSTANT, "constant"), $.identifier_list, ":", $.subtype_indication, optional($.initialiser), ";"
             ),
 
             signal_declaration: $ => seq(
-                $.SIGNAL, $.identifier_list, ":", $.subtype_indication, optional($.signal_kind), optional($.initialiser), ";"
+                alias($.SIGNAL, "signal"), $.identifier_list, ":", $.subtype_indication, optional($.signal_kind), optional($.initialiser), ";"
             ),
 
             signal_kind: $ => choice(
-                $.REGISTER,
-                $.BUS
+                alias($.REGISTER, "register"),
+                alias($.BUS, "bus")
             ),
 
             variable_declaration: $ => seq(
-                optional($.SHARED), $.VARIABLE, $.identifier_list, ":", $.subtype_indication, optional($.generic_map_aspect), optional($.initialiser), ";"
+                optional(alias($.SHARED, "shared")), alias($.VARIABLE, "variable"), $.identifier_list, ":", $.subtype_indication, optional($.generic_map_aspect), optional($.initialiser), ";"
             ),
 
             initialiser: $ => seq(
@@ -575,53 +575,53 @@ module.exports = grammar({
             ),
 
             file_declaration: $ => seq(
-                $.FILE, $.identifier_list, ":", $.subtype_indication, optional($.file_open_information), ";"
+                alias($.FILE, "file"), $.identifier_list, ":", $.subtype_indication, optional($.file_open_information), ";"
             ),
 
             interface_file_declaration: $ => seq(
-                $.FILE, $.identifier_list, ":", $.subtype_indication
+                alias($.FILE, "file"), $.identifier_list, ":", $.subtype_indication
             ),
 
             alias_declaration: $ => seq(
-                $.ALIAS, $._alias_designator, optional(seq(":", $.subtype_indication)), $.IS, $.name, ";"
+                alias(alias($.ALIAS, "alias"), "alias"), $._alias_designator, optional(seq(":", $.subtype_indication)), alias($.IS, "is"), $.name, ";"
             ),
 
             component_declaration: $ => seq(
-                $.COMPONENT, $._identifier, optional($.component_body), $.end_component, ";"
+                alias($.COMPONENT, "component"), $._identifier, optional($.component_body), $.end_component, ";"
             ),
 
             component_body: $ => choice(
-                seq($.IS, optional($.generic_clause), optional($.port_clause)),
+                seq(alias($.IS, "is"), optional($.generic_clause), optional($.port_clause)),
                 seq($.generic_clause, optional($.port_clause)),
                 seq($.port_clause)
             ),
 
             end_component: $ => seq(
-                $.END, optional($.COMPONENT), optional($._identifier)
+                alias($.END, "end"), optional(alias($.COMPONENT, "component")), optional($._identifier)
             ),
 
             attribute_declaration: $ => seq(
-                $.ATTRIBUTE, $._identifier, ":", $.name, ";"
+                alias($.ATTRIBUTE, "attribute"), $._identifier, ":", $.name, ";"
             ),
 
             attribute_specification: $ => seq(
-                $.ATTRIBUTE, $._attribute_designator, $.OF, $.entity_specification, $.IS, $.conditional_expression, ";"
+                alias($.ATTRIBUTE, "attribute"), $._attribute_designator, alias($.OF, "of"), $.entity_specification, alias($.IS, "is"), $.conditional_expression, ";"
             ),
 
             disconnection_specification: $ => seq(
-                $.DISCONNECT, $.guarded_signal_specification, $.AFTER, $._expression, ";"
+                alias($.DISCONNECT, "disconnect"), $.guarded_signal_specification, alias(alias($.AFTER, "after"), "after"), $._expression, ";"
             ),
 
             group_template_declaration: $ => seq(
-                $.GROUP, $._identifier, $.IS, "(", $.entity_class_entry_list, ")", ";"
+                alias($.GROUP, "group"), $._identifier, alias($.IS, "is"), "(", $.entity_class_entry_list, ")", ";"
             ),
 
             group_declaration: $ => seq(
-                $.GROUP, $._identifier, ":", $.name, "(", $.group_constituent_list, ")", ";"
+                alias($.GROUP, "group"), $._identifier, ":", $.name, "(", $.group_constituent_list, ")", ";"
             ),
 
             private_variable_declaration: $ => seq(
-                $.PRIVATE, $.variable_declaration
+                alias($.PRIVATE, "private"), $.variable_declaration
             ),
 
         // Type Definitions
@@ -631,11 +631,11 @@ module.exports = grammar({
             ),
 
             unspecified_type_indication: $ => seq(
-                $.TYPE, $.IS, $._incomplete_type_definition
+                alias($.TYPE, "type"), alias($.IS, "is"), $._incomplete_type_definition
             ),
 
             interface_type_declaration: $ => seq(
-                $.TYPE, $._identifier, optional(seq($.IS, $._incomplete_type_definition))
+                alias($.TYPE, "type"), $._identifier, optional(seq(alias($.IS, "is"), $._incomplete_type_definition))
             ),
 
             _incomplete_type_definition: $ => choice(
@@ -650,29 +650,29 @@ module.exports = grammar({
                 $.file_incomplete_type_definition
             ),
 
-            private_incomplete_type_definition: $ => $.PRIVATE,
+            private_incomplete_type_definition: $ => alias($.PRIVATE, "private"),
 
-            scalar_incomplete_type_definition: $ => $.box,
+            scalar_incomplete_type_definition: $ => alias($.box, "<>"),
 
             discrete_incomplete_type_definition: $ => seq(
-                "(", $.box, ")"
+                "(", alias($.box, "<>"), ")"
             ),
 
             integer_incomplete_type_definition: $ => seq(
-                $.RANGE, $.box
+                alias($.RANGE, "range"), alias($.box, "<>")
             ),
 
             physical_incomplete_type_definition: $ => seq(
-                $.UNITS, $.box
+                alias($.UNITS, "units"), alias($.box, "<>")
             ),
 
             floating_incomplete_type_definition: $ => seq(
-                $.RANGE, $.box, ".", $.box
+                alias($.RANGE, "range"), alias($.box, "<>"), ".", alias($.box, "<>")
             ),
 
             array_type_definition: $ => choice(
-                seq($.ARRAY, "(", $.array_index_incomplete_type_list, ")", $.OF, $._incomplete_subtype_indication),
-                seq($.ARRAY, $.index_constraint, $.OF, $.subtype_indication)
+                seq(alias(alias($.ARRAY, "array"), "array"), "(", $.array_index_incomplete_type_list, ")", alias($.OF, "of"), $._incomplete_subtype_indication),
+                seq(alias(alias($.ARRAY, "array"), "array"), $.index_constraint, alias($.OF, "of"), $.subtype_indication)
             ),
 
             array_index_incomplete_type_list: $ => seq(
@@ -690,23 +690,23 @@ module.exports = grammar({
             )),
 
             index_subtype_definition: $ => seq(
-                $.name, $.RANGE, $.box
+                $.name, alias($.RANGE, "range"), alias($.box, "<>")
             ),
 
             access_type_definition: $ => seq(
-                $.ACCESS, $.subtype_indication, optional($.generic_map_aspect)
+                alias(alias($.ACCESS, "access"), "access"), $.subtype_indication, optional($.generic_map_aspect)
             ),
 
             access_incomplete_type_definition: $ => seq(
-                $.ACCESS, $._incomplete_subtype_indication
+                alias(alias($.ACCESS, "access"), "access"), $._incomplete_subtype_indication
             ),
 
             file_type_definition: $ => seq(
-                $.FILE, $.OF, $.name
+                alias($.FILE, "file"), alias($.OF, "of"), $.name
             ),
 
             file_incomplete_type_definition: $ => seq(
-                $.FILE, $.OF, $.incomplete_type_mark
+                alias($.FILE, "file"), alias($.OF, "of"), $.incomplete_type_mark
             ),
 
             subtype_indication: $ => seq(
@@ -743,11 +743,11 @@ module.exports = grammar({
 
         // Statement Blocks
             concurrent_block: $ => seq(
-                $.BEGIN, repeat($._concurrent_statement)
+                alias($.BEGIN, "begin"), repeat($._concurrent_statement)
             ),
 
             sequential_block: $ => seq(
-                $.BEGIN, repeat($._sequential_statement)
+                alias($.BEGIN, "begin"), repeat($._sequential_statement)
             ),
 
             generate_body: $ => choice(
@@ -756,15 +756,15 @@ module.exports = grammar({
             ),
 
             generate_head: $ => seq(
-                $.GENERATE, repeat($._block_declarative_item)
+                alias($.GENERATE, "generate"), repeat($._block_declarative_item)
             ),
 
             generate_direct_block: $ => seq(
-                $.GENERATE, repeat($._concurrent_statement)
+                alias($.GENERATE, "generate"), repeat($._concurrent_statement)
             ),
 
             case_generate_alternative: $ => prec.left(seq(
-                $.WHEN, optional($.label_declaration), $._element, $.case_generate_body
+                alias($.WHEN, "when"), optional($.label_declaration), $._element, $.case_generate_body
             )),
 
             case_generate_body: $ => choice(
@@ -781,11 +781,11 @@ module.exports = grammar({
             ),
 
             generate_block: $ => seq(
-                $.BEGIN, repeat($._concurrent_statement)
+                alias($.BEGIN, "begin"), repeat($._concurrent_statement)
             ),
 
             generate_block_end: $ => seq(
-                $.END, optional($._label), ";"
+                alias($.END, "end"), optional($._label), ";"
             ),
 
         // Statements
@@ -836,7 +836,7 @@ module.exports = grammar({
             ),
 
             block_statement: $ => seq(
-                $.label_declaration, $.BLOCK, optional($.guard_condition), optional($.block_head), $.concurrent_block, $.end_block, ";"
+                $.label_declaration, alias($.BLOCK, "block"), optional($.guard_condition), optional($.block_head), $.concurrent_block, $.end_block, ";"
             ),
 
             guard_condition: $ => seq(
@@ -844,22 +844,22 @@ module.exports = grammar({
             ),
 
             block_head: $ => choice(
-                seq($.IS, optional(seq($.generic_clause, optional(seq($.generic_map_aspect, ";")))), optional(seq($.port_clause, optional(seq($.port_map_aspect, ";")))), repeat($._block_declarative_item)),
+                seq(alias($.IS, "is"), optional(seq($.generic_clause, optional(seq($.generic_map_aspect, ";")))), optional(seq($.port_clause, optional(seq($.port_map_aspect, ";")))), repeat($._block_declarative_item)),
                 seq($.generic_clause, optional(seq($.generic_map_aspect, ";")), optional(seq($.port_clause, optional(seq($.port_map_aspect, ";")))), repeat($._block_declarative_item)),
                 seq($.port_clause, optional(seq($.port_map_aspect, ";")), repeat($._block_declarative_item)),
                 seq(repeat1($._block_declarative_item))
             ),
 
             end_block: $ => seq(
-                $.END, $.BLOCK, optional($._label)
+                alias($.END, "end"), alias($.BLOCK, "block"), optional($._label)
             ),
 
             sequential_block_statement: $ => seq(
-                optional($.label_declaration), $.BLOCK, optional($.sequential_block_head), $.sequential_block, $.end_block, ";"
+                optional($.label_declaration), alias($.BLOCK, "block"), optional($.sequential_block_head), $.sequential_block, $.end_block, ";"
             ),
 
             sequential_block_head: $ => choice(
-                seq($.IS, repeat($._process_declarative_item)),
+                seq(alias($.IS, "is"), repeat($._process_declarative_item)),
                 seq(repeat1($._process_declarative_item))
             ),
 
@@ -869,9 +869,9 @@ module.exports = grammar({
             ),
 
             instantiated_unit: $ => choice(
-                seq($.COMPONENT, $.name), // Optional "component" covered by procedure call
-                seq($.ENTITY, optional(seq($.library_namespace, ".")), $.name, optional($.architecture_identifier)),
-                seq($.CONFIGURATION, $.name)
+                seq(alias($.COMPONENT, "component"), $.name), // Optional "component" covered by procedure call
+                seq(alias($.ENTITY, "entity"), optional(seq($.library_namespace, ".")), $.name, optional($.architecture_identifier)),
+                seq(alias($.CONFIGURATION, "configuration"), $.name)
             ),
 
             architecture_identifier: $ => seq(
@@ -879,7 +879,7 @@ module.exports = grammar({
             ),
 
             process_statement: $ => seq(
-                optional($.label_declaration), optional($.POSTPONED), $.PROCESS, optional($.sensitivity_specification), optional($.process_head), $.sequential_block, $.end_process, ";"
+                optional($.label_declaration), optional(alias($.POSTPONED, "postponed")), alias($.PROCESS, "process"), optional($.sensitivity_specification), optional($.process_head), $.sequential_block, $.end_process, ";"
             ),
 
             sensitivity_specification: $ => seq(
@@ -887,20 +887,20 @@ module.exports = grammar({
             ),
 
             process_head: $ => choice(
-                seq($.IS, repeat($._process_declarative_item)),
+                seq(alias($.IS, "is"), repeat($._process_declarative_item)),
                 seq(     repeat1($._process_declarative_item)),
             ),
 
             end_process: $ => seq(
-                $.END, optional($.POSTPONED), $.PROCESS, optional($._label)
+                alias($.END, "end"), optional(alias($.POSTPONED, "postponed")), alias($.PROCESS, "process"), optional($._label)
             ),
 
             case_generate_statement: $ => seq(
-                $.label_declaration, $.CASE, $._expression, $.case_generate_block, $.end_generate, ";"
+                $.label_declaration, alias($.CASE, "case"), $._expression, $.case_generate_block, $.end_generate, ";"
             ),
 
             case_generate_block: $ => seq(
-                $.GENERATE, repeat1($.case_generate_alternative)
+                alias($.GENERATE, "generate"), repeat1($.case_generate_alternative)
             ),
 
             for_generate_statement: $ => seq(
@@ -912,19 +912,19 @@ module.exports = grammar({
             ),
 
             if_generate: $ => seq(
-                $.IF, optional($.label_declaration), $._expression, $.generate_body
+                alias($.IF, "if"), optional($.label_declaration), $._expression, $.generate_body
             ),
 
             elsif_generate: $ => seq(
-                $.ELSIF, optional($.label_declaration), $._expression, $.generate_body
+                alias($.ELSIF, "elsif"), optional($.label_declaration), $._expression, $.generate_body
             ),
 
             else_generate: $ => seq(
-                $.ELSE, optional($.label_declaration), $.generate_body
+                alias($.ELSE, "else"), optional($.label_declaration), $.generate_body
             ),
 
             end_generate: $ => seq(
-                $.END, $.GENERATE, optional($._label)
+                alias($.END, "end"), alias($.GENERATE, "generate"), optional($._label)
             ),
 
             assertion_statement: $ => seq(
@@ -932,19 +932,19 @@ module.exports = grammar({
             ),
 
             concurrent_assertion_statement: $ => seq(
-                optional($.label_declaration), optional($.POSTPONED), $.assertion, ";"
+                optional($.label_declaration), optional(alias($.POSTPONED, "postponed")), $.assertion, ";"
             ),
 
             assertion: $ => seq(
-                $.ASSERT, $._expression, optional($.report_expression), optional($.severity_expression)
+                alias(alias($.ASSERT, "assert"), "assert"), $._expression, optional($.report_expression), optional($.severity_expression)
             ),
 
             report_expression: $ => seq(
-                $.REPORT, $._expression
+                alias($.REPORT, "report"), $._expression
             ),
 
             severity_expression: $ => seq(
-                $.SEVERITY, $._expression
+                alias($.SEVERITY, "severity"), $._expression
             ),
 
             case_statement: $ => seq(
@@ -952,23 +952,23 @@ module.exports = grammar({
             ),
 
             case_expression: $ => seq(
-                $.CASE, optional("?"), $._expression
+                alias($.CASE, "case"), optional("?"), $._expression
             ),
 
             case_body: $ => seq(
-                $.IS, repeat1($.case_statement_alternative)
+                alias($.IS, "is"), repeat1($.case_statement_alternative)
             ),
 
             end_case: $ => seq(
-                $.END, $.CASE, optional("?"), optional($._label)
+                alias($.END, "end"), alias($.CASE, "case"), optional("?"), optional($._label)
             ),
 
             exit_statement: $ => seq(
-                optional($.label_declaration), $.EXIT, optional($._label), optional($.when_expression), ";"
+                optional($.label_declaration), alias($.EXIT, "exit"), optional($._label), optional($.when_expression), ";"
             ),
 
             when_expression: $ => seq(
-                $.WHEN, $._expression
+                alias($.WHEN, "when"), $._expression
             ),
 
             if_statement_block: $ => seq(
@@ -976,7 +976,7 @@ module.exports = grammar({
             ),
 
             if_statement: $ => seq(
-                $.IF, $._expression, $.THEN, optional($.if_statement_body)
+                alias($.IF, "if"), $._expression, alias($.THEN, "then"), optional($.if_statement_body)
             ),
 
             if_statement_body: $ => seq(
@@ -984,15 +984,15 @@ module.exports = grammar({
             ),
 
             elsif_statement: $ => seq(
-                $.ELSIF, $._expression, $.THEN, optional($.if_statement_body)
+                alias($.ELSIF, "elsif"), $._expression, alias($.THEN, "then"), optional($.if_statement_body)
             ),
 
             else_statement: $ => seq(
-                $.ELSE, optional($.if_statement_body)
+                alias($.ELSE, "else"), optional($.if_statement_body)
             ),
 
             end_if: $ => seq(
-                $.END, $.IF, optional($._label)
+                alias($.END, "end"), alias($.IF, "if"), optional($._label)
             ),
 
             loop_statement: $ => seq(
@@ -1005,19 +1005,19 @@ module.exports = grammar({
             ),
 
             loop_body: $ => seq(
-                $.LOOP, repeat($._sequential_statement)
+                alias($.LOOP, "loop"), repeat($._sequential_statement)
             ),
 
             end_loop: $ => seq(
-                $.END, $.LOOP, optional($._label)
+                alias($.END, "end"), alias($.LOOP, "loop"), optional($._label)
             ),
 
             next_statement: $ => seq(
-                optional($.label_declaration), $.NEXT, optional($._label), optional($.when_expression), ";"
+                optional($.label_declaration), alias($.NEXT, "next"), optional($._label), optional($.when_expression), ";"
             ),
 
             null_statement: $ => seq(
-                optional($.label_declaration), $.NULL, ";"
+                optional($.label_declaration), alias($.NULL, "null"), ";"
             ),
 
             procedure_call_statement: $ => seq(
@@ -1025,7 +1025,7 @@ module.exports = grammar({
             ),
 
             concurrent_procedure_call_statement: $ => seq(
-                optional($.label_declaration), optional($.POSTPONED), $.name, ";"
+                optional($.label_declaration), optional(alias($.POSTPONED, "postponed")), $.name, ";"
             ),
 
             report_statement: $ => seq(
@@ -1033,8 +1033,8 @@ module.exports = grammar({
             ),
 
             return_statement: $ => choice(
-                seq(optional($.label_declaration), $.RETURN, optional($.when_expression), ";"),
-                seq(optional($.label_declaration), $.RETURN, $.conditional_or_unaffected_expression, ";")
+                seq(optional($.label_declaration), alias($.RETURN, "return"), optional($.when_expression), ";"),
+                seq(optional($.label_declaration), alias($.RETURN, "return"), $.conditional_or_unaffected_expression, ";")
             ),
 
             signal_assignment: $ => "<=",
@@ -1050,15 +1050,15 @@ module.exports = grammar({
             ),
 
             concurrent_simple_signal_assignment: $ => seq(
-                optional($.label_declaration), optional($.POSTPONED), $._target, $.signal_assignment, optional($.GUARDED), optional($.delay_mechanism), $.waveform, ";"
+                optional($.label_declaration), optional(alias($.POSTPONED, "postponed")), $._target, $.signal_assignment, optional(alias($.GUARDED, "guarded")), optional($.delay_mechanism), $.waveform, ";"
             ),
 
             simple_force_assignment: $ => seq(
-                optional($.label_declaration), $._target, $.signal_assignment, $.FORCE, optional($.force_mode), $.conditional_or_unaffected_expression, ";"
+                optional($.label_declaration), $._target, $.signal_assignment, alias($.FORCE, "force"), optional($.force_mode), $.conditional_or_unaffected_expression, ";"
             ),
 
             simple_release_assignment: $ => seq(
-                optional($.label_declaration), $._target, $.signal_assignment, $.RELEASE, optional($.force_mode), ";"
+                optional($.label_declaration), $._target, $.signal_assignment, alias($.RELEASE, "release"), optional($.force_mode), ";"
             ),
 
             conditional_signal_assignment: $ => seq(
@@ -1066,7 +1066,7 @@ module.exports = grammar({
             ),
 
             concurrent_conditional_signal_assignment: $ => seq(
-                optional($.label_declaration), optional($.POSTPONED), $._target, $.signal_assignment, optional($.GUARDED), optional($.delay_mechanism), $.conditional_waveforms, ";"
+                optional($.label_declaration), optional(alias($.POSTPONED, "postponed")), $._target, $.signal_assignment, optional(alias($.GUARDED, "guarded")), optional($.delay_mechanism), $.conditional_waveforms, ";"
             ),
 
             selected_waveform_assignment: $ => seq(
@@ -1074,11 +1074,11 @@ module.exports = grammar({
             ),
 
             concurrent_selected_signal_assignment: $ => seq(
-                optional($.label_declaration), optional($.POSTPONED), $.with_expression, $.select_target, $.signal_assignment, optional($.GUARDED), optional($.delay_mechanism), $.selected_waveforms, ";"
+                optional($.label_declaration), optional(alias($.POSTPONED, "postponed")), $.with_expression, $.select_target, $.signal_assignment, optional(alias($.GUARDED, "guarded")), optional($.delay_mechanism), $.selected_waveforms, ";"
             ),
 
             selected_force_assignment: $ => seq(
-                optional($.label_declaration), $.with_expression, $.select_target, $.signal_assignment, $.FORCE, optional($.force_mode), $.selected_expressions, ";"
+                optional($.label_declaration), $.with_expression, $.select_target, $.signal_assignment, alias($.FORCE, "force"), optional($.force_mode), $.selected_expressions, ";"
             ),
 
             selected_variable_assignment: $ => seq(
@@ -1086,15 +1086,15 @@ module.exports = grammar({
             ),
 
             with_expression: $ => seq(
-                $.WITH, $._expression
+                alias($.WITH, "with"), $._expression
             ),
 
             select_target: $ => seq(
-                $.SELECT, optional("?"), $._target
+                alias($.SELECT, "select"), optional("?"), $._target
             ),
 
             wait_statement: $ => seq(
-                optional($.label_declaration), $.WAIT, optional($.sensitivity_clause), optional($.condition_clause), optional($.timeout_clause), ";"
+                optional($.label_declaration), alias($.WAIT, "wait"), optional($.sensitivity_clause), optional($.condition_clause), optional($.timeout_clause), ";"
             ),
 
         // Expressions
@@ -1103,7 +1103,7 @@ module.exports = grammar({
             )),
 
             else_expression: $ => seq(
-                $.ELSE, $._expression
+                alias($.ELSE, "else"), $._expression
             ),
 
             _expression: $ => prec(10, choice(
@@ -1268,15 +1268,15 @@ module.exports = grammar({
             ),
 
             external_constant_name: $ => seq(
-                "<<", $.CONSTANT, $._external_pathname, ":", $._interface_type_indication, ">>"
+                "<<", alias($.CONSTANT, "constant"), $._external_pathname, ":", $._interface_type_indication, ">>"
             ),
 
             external_signal_name: $ => seq(
-                "<<", $.SIGNAL, $._external_pathname, ":", $._interface_type_indication, ">>"
+                "<<", alias($.SIGNAL, "signal"), $._external_pathname, ":", $._interface_type_indication, ">>"
             ),
 
             external_variable_name: $ => seq(
-                "<<", $.VARIABLE, $._external_pathname, ":", $._interface_type_indication, ">>"
+                "<<", alias($.VARIABLE, "variable"), $._external_pathname, ":", $._interface_type_indication, ">>"
             ),
 
             _external_pathname: $ => choice(
@@ -1306,8 +1306,8 @@ module.exports = grammar({
             ),
 
             function_call: $ => prec.right(choice(
-                seq(optional($.generic_map_aspect), $.PARAMETER, $.MAP, $.parenthesis_group),
-                seq($.generic_map_aspect, optional(seq(optional(seq($.PARAMETER, $.MAP)), $.parenthesis_group)))
+                seq(optional($.generic_map_aspect), alias($.PARAMETER, "parameter"), alias($.MAP, "map"), $.parenthesis_group),
+                seq($.generic_map_aspect, optional(seq(optional(seq(alias($.PARAMETER, "parameter"), alias($.MAP, "map"))), $.parenthesis_group)))
             )),
 
             parenthesis_group: $ => seq(
@@ -1331,8 +1331,8 @@ module.exports = grammar({
             ),
 
             _actual_part: $ => prec(21, choice(
-                seq(optional($.INERTIAL), $.conditional_expression),
-                $.OPEN
+                seq(optional(alias($.INERTIAL, "inertial")), $.conditional_expression),
+                alias($.OPEN, "open")
             )),
 
             attribute: $ => seq(
@@ -1358,7 +1358,7 @@ module.exports = grammar({
             ),
 
             signature: $ => seq(
-                "[", optional(seq($.name, repeat(seq(",", $.name)))), optional(seq($.RETURN, $.name)), "]"
+                "[", optional(seq($.name, repeat(seq(",", $.name)))), optional(seq(alias($.RETURN, "return"), $.name)), "]"
             ),
 
             selection: $ => seq(
@@ -1369,7 +1369,7 @@ module.exports = grammar({
                 $.identifier,
                 $.character_literal,
                 $.operator_symbol,
-                $.ALL
+                alias(alias($.ALL, "all"), "all")
             ),
 
             _literal: $ => choice(
@@ -1382,7 +1382,7 @@ module.exports = grammar({
                 $.library_constant_debug,
                 $.library_constant_env,
                 $.library_constant_standard,
-                $.NULL
+                alias($.NULL, "null")
             ),
 
             bit_string_literal: $ => seq(
@@ -1402,7 +1402,7 @@ module.exports = grammar({
             ),
 
             allocator: $ => seq(
-                $.NEW, $.name
+                alias($.NEW, "new"), $.name
             ),
 
             parenthesis_expression: $ => seq(
@@ -1421,7 +1421,7 @@ module.exports = grammar({
             _element: $ => choice(
                 $.simple_expression,
                 $._range,
-                $.OTHERS,
+                alias($.OTHERS, "others"),
                 $.choices
             ),
 
@@ -1439,8 +1439,8 @@ module.exports = grammar({
             )),
 
             _direction: $ => choice(
-                $.TO,
-                $.DOWNTO
+                alias($.TO, "to"),
+                alias($.DOWNTO, "downto")
             ),
 
         // Tool Directives
@@ -1477,19 +1477,19 @@ module.exports = grammar({
             ),
 
             if_conditional_analysis: $ => seq(
-                $.IF, $.conditional_analysis_expression, $.THEN
+                alias($.IF, "if"), $.conditional_analysis_expression, alias($.THEN, "then")
             ),
 
             elsif_conditional_analysis: $ => seq(
-                $.ELSIF, $.conditional_analysis_expression, $.THEN
+                alias($.ELSIF, "elsif"), $.conditional_analysis_expression, alias($.THEN, "then")
             ),
 
             else_conditional_analysis: $ => seq(
-                $.ELSE
+                alias($.ELSE, "else")
             ),
 
             end_conditional_analysis: $ => seq(
-                $.END, optional($.IF)
+                alias($.END, "end"), optional(alias($.IF, "if"))
             ),
 
             conditional_analysis_expression: $ => seq(
@@ -1528,15 +1528,15 @@ module.exports = grammar({
             ),
 
             block_configuration: $ => seq(
-                $.FOR, $.name, repeat($.use_clause), repeat($._configuration_item), $.end_for, ";"
+                alias($.FOR, "for"), $.name, repeat($.use_clause), repeat($._configuration_item), $.end_for, ";"
             ),
 
             component_configuration: $ => seq(
-                $.FOR, $.component_specification, optional($.binding_indication), repeat(seq($.verification_unit_binding_indication, ";")), optional($.block_configuration), $.end_for, ";"
+                alias($.FOR, "for"), $.component_specification, optional($.binding_indication), repeat(seq($.verification_unit_binding_indication, ";")), optional($.block_configuration), $.end_for, ";"
             ),
 
             end_for: $ => seq(
-                $.END, $.FOR
+                alias($.END, "end"), alias($.FOR, "for")
             ),
 
         // Interface Declaration
@@ -1561,19 +1561,19 @@ module.exports = grammar({
             ),
 
             interface_constant_declaration: $ => seq(
-                $.CONSTANT, $.identifier_list, ":", $._mode_indication
+                alias($.CONSTANT, "constant"), $.identifier_list, ":", $._mode_indication
             ),
 
             interface_signal_declaration: $ => seq(
-                $.SIGNAL, $.identifier_list, ":", $._mode_indication
+                alias($.SIGNAL, "signal"), $.identifier_list, ":", $._mode_indication
             ),
 
             interface_variable_declaration: $ => seq(
-                $.VARIABLE, $.identifier_list, ":", $._mode_indication
+                alias($.VARIABLE, "variable"), $.identifier_list, ":", $._mode_indication
             ),
 
             interface_subprogram_declaration: $ => seq(
-                $._interface_subprogram_specification, optional(seq($.IS, $._interface_subprogram_default))
+                $._interface_subprogram_specification, optional(seq(alias($.IS, "is"), $._interface_subprogram_default))
             ),
 
             _interface_subprogram_specification: $ => choice(
@@ -1582,19 +1582,19 @@ module.exports = grammar({
             ),
 
             procedure_specification: $ => prec.left(seq(
-                $.PROCEDURE, $._designator, optional($.subprogram_header), optional($.parameter_list_specification)
+                alias($.PROCEDURE, "procedure"), $._designator, optional($.subprogram_header), optional($.parameter_list_specification)
             )),
 
             interface_procedure_specification: $ => seq(
-                $.PROCEDURE, $._designator, optional($.parameter_list_specification)
+                alias($.PROCEDURE, "procedure"), $._designator, optional($.parameter_list_specification)
             ),
 
             function_specification: $ => seq(
-                optional(choice($.PURE, $.IMPURE)), $.FUNCTION, $._designator, optional($.subprogram_header), optional($.parameter_list_specification), $.RETURN, optional(seq($._identifier, $.OF)), $.name
+                optional(choice(alias($.PURE, "pure"), alias($.IMPURE, "impure"))), alias($.FUNCTION, "function"), $._designator, optional($.subprogram_header), optional($.parameter_list_specification), alias($.RETURN, "return"), optional(seq($._identifier, alias($.OF, "of"))), $.name
             ),
 
             interface_function_specification: $ => seq(
-                optional(choice($.PURE, $.IMPURE)), $.FUNCTION, $._designator, optional($.parameter_list_specification), $.RETURN, $.name
+                optional(choice(alias($.PURE, "pure"), alias($.IMPURE, "impure"))), alias($.FUNCTION, "function"), $._designator, optional($.parameter_list_specification), alias($.RETURN, "return"), $.name
             ),
 
             _interface_package_generic_map_aspect: $ => choice(
@@ -1604,19 +1604,19 @@ module.exports = grammar({
             ),
 
             generic_map_any: $ => seq(
-                $.GENERIC, $.MAP, "(", $.box, ")"
+                alias($.GENERIC, "generic"), alias($.MAP, "map"), "(", alias($.box, "<>"), ")"
             ),
 
             generic_map_default: $ => seq(
-                $.GENERIC, $.MAP, "(", $.DEFAULT, ")"
+                alias($.GENERIC, "generic"), alias($.MAP, "map"), "(", alias($.DEFAULT, "default"), ")"
             ),
 
             generic_map_aspect: $ => seq(
-                $.GENERIC, $.MAP, $.association_list
+                alias($.GENERIC, "generic"), alias($.MAP, "map"), $.association_list
             ),
 
             port_map_aspect: $ => seq(
-                $.PORT, $.MAP, $.association_list
+                alias($.PORT, "port"), alias($.MAP, "map"), $.association_list
             ),
 
             association_list: $ => seq(
@@ -1625,7 +1625,7 @@ module.exports = grammar({
 
             _interface_subprogram_default: $ => choice(
                 $.name,
-                $.box
+                alias($.box, "<>")
             ),
 
             _designator: $ => choice(
@@ -1643,7 +1643,7 @@ module.exports = grammar({
             ),
 
             simple_mode_indication: $ => seq(
-                optional($.mode), $._interface_type_indication, optional($.BUS), optional($.initialiser)
+                optional($.mode), $._interface_type_indication, optional(alias($.BUS, "bus")), optional($.initialiser)
             ),
 
             _mode_view_indication: $ => choice(
@@ -1652,11 +1652,11 @@ module.exports = grammar({
             ),
 
             record_mode_view_indication: $ => seq(
-                $.VIEW, $.name, optional(seq($.OF, $.subtype_indication))
+                alias($.VIEW, "view"), $.name, optional(seq(alias($.OF, "of"), $.subtype_indication))
             ),
 
             array_mode_view_indication: $ => seq(
-                $.VIEW, "(", $.name, ")", optional(seq($.OF, $.subtype_indication))
+                alias($.VIEW, "view"), "(", $.name, ")", optional(seq(alias($.OF, "of"), $.subtype_indication))
             ),
 
             mode_view_element_definition: $ => seq(
@@ -1678,24 +1678,24 @@ module.exports = grammar({
             ),
 
             element_record_mode_view_indication: $ => seq(
-                $.VIEW, $.name
+                alias($.VIEW, "view"), $.name
             ),
 
             element_array_mode_view_indication: $ => seq(
-                $.VIEW, "(", $.name, ")"
+                alias($.VIEW, "view"), "(", $.name, ")"
             ),
 
             mode: $ => choice(
-                $.IN,
-                $.OUT,
-                $.INOUT,
-                $.BUFFER,
-                $.LINKAGE
+                alias($.IN, "in"),
+                alias($.OUT, "out"),
+                alias($.INOUT, "inout"),
+                alias($.BUFFER, "buffer"),
+                alias($.LINKAGE, "linkage")
             ),
 
         // Others
             range_constraint: $ => seq(
-                $.RANGE, $._range
+                alias($.RANGE, "range"), $._range
             ),
 
             group_constituent_list: $ => seq(
@@ -1707,7 +1707,7 @@ module.exports = grammar({
             ),
 
             entity_class_entry: $ => seq(
-                $._entity_class, optional($.box)
+                $._entity_class, optional(alias($.box, "<>"))
             ),
 
             guarded_signal_specification: $ => seq(
@@ -1716,8 +1716,8 @@ module.exports = grammar({
 
             signal_list: $ => choice(
                 seq($.name, repeat(seq(",", $.name))),
-                $.OTHERS,
-                $.ALL
+                alias($.OTHERS, "others"),
+                alias(alias($.ALL, "all"), "all")
             ),
 
             entity_specification: $ => seq(
@@ -1725,32 +1725,32 @@ module.exports = grammar({
             ),
 
             _entity_class: $ => choice(
-                $.ENTITY,
-                $.ARCHITECTURE,
-                $.CONFIGURATION,
-                $.PROCEDURE,
-                $.FUNCTION,
-                $.PACKAGE,
-                $.TYPE,
-                $.SUBTYPE,
-                $.CONSTANT,
-                $.SIGNAL,
-                $.VARIABLE,
-                $.COMPONENT,
-                $.LABEL,
-                $.LITERAL,
-                $.UNITS,
-                $.GROUP,
-                $.FILE,
-                $.PROPERTY,
-                $.SEQUENCE,
-                $.VIEW
+                alias($.ENTITY, "entity"),
+                alias(alias($.ARCHITECTURE, "architecture"), "architecture"),
+                alias($.CONFIGURATION, "configuration"),
+                alias($.PROCEDURE, "procedure"),
+                alias($.FUNCTION, "function"),
+                alias($.PACKAGE, "package"),
+                alias($.TYPE, "type"),
+                alias($.SUBTYPE, "subtype"),
+                alias($.CONSTANT, "constant"),
+                alias($.SIGNAL, "signal"),
+                alias($.VARIABLE, "variable"),
+                alias($.COMPONENT, "component"),
+                alias($.LABEL, "label"),
+                alias($.LITERAL, "literal"),
+                alias($.UNITS, "units"),
+                alias($.GROUP, "group"),
+                alias($.FILE, "file"),
+                alias($.PROPERTY, "property"),
+                alias($.SEQUENCE, "sequence"),
+                alias($.VIEW, "view")
             ),
 
             entity_name_list: $ => choice(
                 seq($.entity_designator, repeat(seq(",", $.entity_designator))),
-                $.OTHERS,
-                $.ALL
+                alias($.OTHERS, "others"),
+                alias(alias($.ALL, "all"), "all")
             ),
 
             entity_designator: $ => seq(
@@ -1770,7 +1770,7 @@ module.exports = grammar({
             ),
 
             file_open_information: $ => seq(
-                optional(seq($.OPEN, $._expression)), $.IS, $.file_logical_name
+                optional(seq(alias($.OPEN, "open"), $._expression)), alias($.IS, "is"), $.file_logical_name
             ),
 
             file_logical_name: $ => $._expression,
@@ -1780,11 +1780,11 @@ module.exports = grammar({
             ),
 
             generic_clause: $ => seq(
-                $.GENERIC, "(", $.interface_list, ")", ";"
+                alias($.GENERIC, "generic"), "(", $.interface_list, ")", ";"
             ),
 
             subprogram_header: $ => seq(
-                $.GENERIC, "(", $.interface_list, ")", optional($.generic_map_aspect)
+                alias($.GENERIC, "generic"), "(", $.interface_list, ")", optional($.generic_map_aspect)
             ),
 
             _subprogram_specification: $ => choice(
@@ -1793,7 +1793,7 @@ module.exports = grammar({
             ),
 
             parameter_list_specification: $ => seq(
-                optional($.PARAMETER), "(", $.interface_list, ")"
+                optional(alias($.PARAMETER, "parameter")), "(", $.interface_list, ")"
             ),
 
             _type_definition: $ => choice(
@@ -1810,15 +1810,15 @@ module.exports = grammar({
             ),
 
             protected_type_instantiation_definition: $ => seq(
-                $.NEW, $.subtype_indication, optional($.generic_map_aspect)
+                alias($.NEW, "new"), $.subtype_indication, optional($.generic_map_aspect)
             ),
 
             protected_type_declaration: $ => seq(
-                $.PROTECTED, optional($.protected_type_header), repeat($._protected_type_declarative_item), $.protected_type_declaration_end
+                alias($.PROTECTED, "protected"), optional($.protected_type_header), repeat($._protected_type_declarative_item), $.protected_type_declaration_end
             ),
 
             protected_type_declaration_end: $ => seq(
-                $.END, $.PROTECTED, optional($._identifier)
+                alias($.END, "end"), alias($.PROTECTED, "protected"), optional($._identifier)
             ),
 
             protected_type_header: $ => seq(
@@ -1826,23 +1826,23 @@ module.exports = grammar({
             ),
 
             protected_type_body: $ => seq(
-                $.PROTECTED, $.BODY, repeat($._protected_type_body_declarative_item), $.protected_type_body_end
+                alias($.PROTECTED, "protected"), alias($.BODY, "body"), repeat($._protected_type_body_declarative_item), $.protected_type_body_end
             ),
 
             protected_type_body_end: $ => seq(
-                $.END, $.PROTECTED, $.BODY, optional($._identifier)
+                alias($.END, "end"), alias($.PROTECTED, "protected"), alias($.BODY, "body"), optional($._identifier)
             ),
 
             while_loop: $ => seq(
-                $.WHILE, $._expression
+                alias($.WHILE, "while"), $._expression
             ),
 
             for_loop: $ => seq(
-                $.FOR, $.parameter_specification
+                alias($.FOR, "for"), $.parameter_specification
             ),
 
             parameter_specification: $ => seq(
-                $._identifier, $.IN, $._range
+                $._identifier, alias($.IN, "in"), $._range
             ),
 
             case_statement_alternative: $ => seq(
@@ -1855,16 +1855,16 @@ module.exports = grammar({
 
             waveform: $ => choice(
                 seq($.waveform_element, repeat(seq(",", $.waveform_element))),
-                $.UNAFFECTED
+                alias($.UNAFFECTED, "unaffected")
             ),
 
             waveform_element: $ => seq(
-                $._expression, optional(seq($.AFTER, $._expression)),
+                $._expression, optional(seq(alias(alias($.AFTER, "after"), "after"), $._expression)),
             ),
 
             force_mode: $ => choice(
-                $.IN,
-                $.OUT
+                alias($.IN, "in"),
+                alias($.OUT, "out")
             ),
 
             selected_expressions: $ => seq(
@@ -1872,7 +1872,7 @@ module.exports = grammar({
             ),
 
             when_element: $ => seq(
-                $.WHEN, $._element
+                alias($.WHEN, "when"), $._element
             ),
 
             conditional_waveforms: $ => seq(
@@ -1880,12 +1880,12 @@ module.exports = grammar({
             ),
 
             else_waveform: $ => seq(
-                $.ELSE, $.waveform
+                alias($.ELSE, "else"), $.waveform
             ),
 
             delay_mechanism: $ => choice(
-                $.TRANSPORT,
-                seq(optional(seq($.REJECT, $._expression)), $.INERTIAL)
+                alias($.TRANSPORT, "transport"),
+                seq(optional(seq(alias($.REJECT, "reject"), $._expression)), alias($.INERTIAL, "inertial"))
             ),
 
             _target: $ => choice(
@@ -1904,12 +1904,12 @@ module.exports = grammar({
             ),
 
             else_expression_or_unaffected: $ => seq(
-                $.ELSE, $._expression_or_unaffected
+                alias($.ELSE, "else"), $._expression_or_unaffected
             ),
 
             _expression_or_unaffected: $ => choice(
                 $._expression,
-                $.UNAFFECTED
+                alias($.UNAFFECTED, "unaffected")
             ),
 
             label_declaration: $ => seq(
@@ -1917,7 +1917,7 @@ module.exports = grammar({
             ),
 
             sensitivity_clause: $ => seq(
-                $.ON, $.sensitivity_list
+                alias($.ON, "on"), $.sensitivity_list
             ),
 
             sensitivity_list: $ => seq(
@@ -1925,15 +1925,15 @@ module.exports = grammar({
             ),
 
             condition_clause: $ => seq(
-                $.UNTIL, $._expression
+                alias($.UNTIL, "until"), $._expression
             ),
 
             timeout_clause: $ => seq(
-                $.FOR, $._expression
+                alias($.FOR, "for"), $._expression
             ),
 
             physical_type_definition: $ => seq(
-                $.range_constraint, $.UNITS, $.primary_unit_declaration, repeat($.secondary_unit_declaration), $.end_units
+                $.range_constraint, alias($.UNITS, "units"), $.primary_unit_declaration, repeat($.secondary_unit_declaration), $.end_units
             ),
 
             primary_unit_declaration: $ => seq(
@@ -1945,7 +1945,7 @@ module.exports = grammar({
             ),
 
             end_units: $ => seq(
-                $.END, $.UNITS, optional($._identifier)
+                alias($.END, "end"), alias($.UNITS, "units"), optional($._identifier)
             ),
 
             enumeration_type_definition: $ => seq(
@@ -1958,11 +1958,11 @@ module.exports = grammar({
             ),
 
             record_type_definition: $ => seq(
-                $.RECORD, repeat($.element_declaration), $.end_record
+                alias($.RECORD, "record"), repeat($.element_declaration), $.end_record
             ),
 
             end_record: $ => seq(
-                $.END, $.RECORD, optional($._identifier)
+                alias($.END, "end"), alias($.RECORD, "record"), optional($._identifier)
             ),
 
             element_declaration: $ => seq(
@@ -1970,17 +1970,17 @@ module.exports = grammar({
             ),
 
             _process_sensitivity_list: $ => choice(
-                $.ALL,
+                alias(alias($.ALL, "all"), "all"),
                 $.sensitivity_list
             ),
 
             configuration_specification: $ => prec.left(choice(
-                seq($.FOR, $.component_specification, $.binding_indication, optional(seq($.end_for, ";"))),
-                seq($.FOR, $.component_specification, $.binding_indication, $.verification_unit_binding_indication, ";", repeat(seq($.verification_unit_binding_indication, ";")), $.end_for, ";")
+                seq(alias($.FOR, "for"), $.component_specification, $.binding_indication, optional(seq($.end_for, ";"))),
+                seq(alias($.FOR, "for"), $.component_specification, $.binding_indication, $.verification_unit_binding_indication, ";", repeat(seq($.verification_unit_binding_indication, ";")), $.end_for, ";")
             )),
 
             verification_unit_binding_indication: $ => seq(
-                $.USE, $.VUNIT, $.verification_unit_list
+                alias($.USE, "use"), alias($.VUNIT, "vunit"), $.verification_unit_list
             ),
 
             verification_unit_list: $ => seq(
@@ -1993,18 +1993,18 @@ module.exports = grammar({
 
             instantiation_list: $ => choice(
                 seq($._label, repeat(seq(",", $._label))),
-                $.OTHERS,
-                $.ALL
+                alias($.OTHERS, "others"),
+                alias(alias($.ALL, "all"), "all")
             ),
 
             binding_indication: $ => seq(
-                optional(seq($.USE, $.entity_aspect)), optional($.generic_map_aspect), optional($.port_map_aspect), ";"
+                optional(seq(alias($.USE, "use"), $.entity_aspect)), optional($.generic_map_aspect), optional($.port_map_aspect), ";"
             ),
 
             entity_aspect: $ => choice(
-                seq($.ENTITY, $.name, optional(seq("(", $._identifier, ")"))),
-                seq($.CONFIGURATION, $.name),
-                $.OPEN
+                seq(alias($.ENTITY, "entity"), $.name, optional(seq("(", $._identifier, ")"))),
+                seq(alias($.CONFIGURATION, "configuration"), $.name),
+                alias($.OPEN, "open")
             ),
 
         // Comments

--- a/queries/Helix/highlights.scm
+++ b/queries/Helix/highlights.scm
@@ -11,193 +11,193 @@
 (identifier) @variable
 
 [
-  (ACCESS)
-  (AFTER)
-  (ALIAS)
-  (ARCHITECTURE)
-  (ARRAY)
-  (ASSUME)
-  (ATTRIBUTE)
-  (BLOCK)
-  (BODY)
-  (COMPONENT)
-  (CONFIGURATION)
-  (CONTEXT)
-  (COVER)
-  (DISCONNECT)
-  (ENTITY)
-  (FAIRNESS)
-  (FILE)
-  (FORCE)
-  (GENERATE)
-  (GENERIC)
-  (GROUP)
-  (LABEL)
-  (LITERAL)
-  (MAP)
-  (NEW)
-  (PACKAGE)
-  (PARAMETER)
-  (PORT)
-  (PROPERTY)
-  (RANGE)
-  (REJECT)
-  (RELEASE)
-  (RESTRICT)
-  (SEQUENCE)
-  (TRANSPORT)
-  (UNAFFECTED)
-  (VIEW)
-  (VPKG)
-  (VMODE)
-  (VPROP)
-  (VUNIT)
+  "access"
+  "after"
+  "alias"
+  "architecture"
+  "array"
+  ; "assume"
+  "attribute"
+  "block"
+  "body"
+  "component"
+  "configuration"
+  "context"
+  ; "cover"
+  "disconnect"
+  "entity"
+  ; "fairness"
+  "file"
+  "force"
+  "generate"
+  "generic"
+  "group"
+  "label"
+  "literal"
+  "map"
+  "new"
+  "package"
+  "parameter"
+  "port"
+  "property"
+  "range"
+  "reject"
+  "release"
+  ; "restrict"
+  "sequence"
+  "transport"
+  "unaffected"
+  "view"
+  ; "vmode"
+  ; "vpkg"
+  ; "vprop"
+  "vunit"
 ] @keyword
 
 [
-  (ALL)
-  (OTHERS)
-  (box)
-  (DEFAULT)
-  (OPEN)
+  "all"
+  "others"
+  "<>"
+  "default"
+  "open"
 ] @constant.builtin
 
 [
-  (IS)
-  (BEGIN)
-  (END)
+  "is"
+  "begin"
+  "end"
 ] @keyword
 
 (parameter_specification
-  (IN) @keyword)
+  "in" @keyword)
 
 [
-  (PROCESS)
-  (WAIT)
-  (ON)
-  (UNTIL)
+  "process"
+  "wait"
+  "on"
+  "until"
 ] @keyword
 
 (timeout_clause
-  (FOR) @keyword)
+  "for" @keyword)
 
 [
-  (FUNCTION)
-  (PROCEDURE)
+  "function"
+  "procedure"
 ] @keyword.function
 
 [
-  (TO)
-  (DOWNTO)
-  (OF)
+  "to"
+  "downto"
+  "of"
 ] @keyword.operator
 
 [
-  (LIBRARY)
-  (USE)
+  "library"
+  "use"
 ] @keyword.control.import
 
 [
-  (SUBTYPE)
-  (TYPE)
-  (RECORD)
-  (UNITS)
-  (CONSTANT)
-  (SIGNAL)
-  (VARIABLE)
+  "subtype"
+  "type"
+  "record"
+  "units"
+  "constant"
+  "signal"
+  "variable"
 ] @keyword.storage.type
 
 [
-  (PROTECTED)
-  (PRIVATE)
-  (PURE)
-  (IMPURE)
-  (INERTIAL)
-  (POSTPONED)
-  (STRONG)
-  (GUARDED)
-  (OUT)
-  (INOUT)
-  (LINKAGE)
-  (BUFFER)
-  (REGISTER)
-  (BUS)
-  (SHARED)
+  "protected"
+  "private"
+  "pure"
+  "impure"
+  "inertial"
+  "postponed"
+  ; "strong"
+  "guarded"
+  "out"
+  "inout"
+  "linkage"
+  "buffer"
+  "register"
+  "bus"
+  "shared"
 ] @keyword.storage.modifier
 
 (mode
-  (IN) @keyword.storage.modifier)
+  "in" @keyword.storage.modifier)
 
 (force_mode
-  (IN) @keyword.storage.modifier)
+  "in" @keyword.storage.modifier)
 
 [
-  (WHILE)
-  (LOOP)
-  (NEXT)
-  (EXIT)
+  "while"
+  "loop"
+  "next"
+  "exit"
 ] @keyword.control.repeat
 
 (for_loop
-  (FOR) @keyword.control.repeat)
+  "for" @keyword.control.repeat)
 
 (block_configuration
-  (FOR) @keyword)
+  "for" @keyword)
 
 (configuration_specification
-  (FOR) @keyword)
+  "for" @keyword)
 
 (component_configuration
-  (FOR) @keyword)
+  "for" @keyword)
 
 (end_for
-  (FOR) @keyword)
+  "for" @keyword)
 
-(RETURN) @keyword.control.return
+"return" @keyword.control.return
 
 [
-  (ASSERT)
-  (REPORT)
-  (SEVERITY)
+  "assert"
+  "report"
+  "severity"
 ] @keyword
 
 [
-  (IF)
-  (THEN)
-  (ELSIF)
-  (CASE)
+  "if"
+  "then"
+  "elsif"
+  "case"
 ] @keyword.control.conditional
 
 (when_element
-  (WHEN) @keyword.control.conditional)
+  "when" @keyword.control.conditional)
 
 (case_generate_alternative
-  (WHEN) @keyword.control.conditional)
+  "when" @keyword.control.conditional)
 
 (else_statement
-  (ELSE) @keyword.control.conditional)
+  "else" @keyword.control.conditional)
 
 (else_generate
-  (ELSE) @keyword.control.conditional)
+  "else" @keyword.control.conditional)
 
 [
-  (WITH)
-  (SELECT)
+  "with"
+  "select"
 ] @keyword.control.conditional
 
 (when_expression
-  (WHEN) @keyword.control.conditional)
+  "when" @keyword.control.conditional)
 
 (else_expression
-  (ELSE) @keyword.control.conditional)
+  "else" @keyword.control.conditional)
 
 (else_waveform
-  (ELSE) @keyword.control.conditional)
+  "else" @keyword.control.conditional)
 
 (else_expression_or_unaffected
-  (ELSE) @keyword.control.conditional)
+  "else" @keyword.control.conditional)
 
-(NULL) @constant.builtin
+"null" @constant.builtin
 
 (user_directive) @keyword.directive
 
@@ -208,22 +208,22 @@
 (error_directive) @keyword.directive
 
 (if_conditional_analysis
-  (IF) @keyword.directive)
+  "if" @keyword.directive)
 
 (if_conditional_analysis
-  (THEN) @keyword.directive)
+  "then" @keyword.directive)
 
 (elsif_conditional_analysis
-  (ELSIF) @keyword.directive)
+  "elsif" @keyword.directive)
 
 (else_conditional_analysis
-  (ELSE) @keyword.directive)
+  "else" @keyword.directive)
 
 (end_conditional_analysis
-  (END) @keyword.directive)
+  "end" @keyword.directive)
 
 (end_conditional_analysis
-  (IF) @keyword.directive)
+  "if" @keyword.directive)
 
 (directive_body) @keyword.directive
 
@@ -330,12 +330,12 @@
 (label) @label
 
 (generic_map_aspect
-  (GENERIC) @constructor
-  (MAP) @constructor)
+  "generic" @constructor
+  "map" @constructor)
 
 (port_map_aspect
-  (PORT) @constructor
-  (MAP) @constructor)
+  "port" @constructor
+  "map" @constructor)
 
 (subtype_indication
   (name
@@ -400,9 +400,9 @@
   (identifier) @namespace)
 
 (architecture_definition
-  (ARCHITECTURE)
+  "architecture"
   (identifier) @type.parameter
-  (OF)
+  "of"
   (name
     (identifier) @namespace))
 

--- a/queries/Helix/highlights.scm
+++ b/queries/Helix/highlights.scm
@@ -298,24 +298,9 @@
 
 (library_constant_std_logic) @constant.builtin
 
-[
-  (attribute_function)
-  (attribute_impure_function)
-  (attribute_mode_view)
-  (attribute_pure_function)
-  (attribute_range)
-  (attribute_signal)
-  (attribute_subtype)
-  (attribute_type)
-  (attribute_value)
-  (library_attribute)
-] @attribute
-
 (library_constant) @constant.builtin
 
 (library_function) @function.builtin
-
-(library_type) @type.builtin
 
 (library_constant_boolean) @constant.builtin.boolean
 
@@ -337,79 +322,32 @@
   "port" @constructor
   "map" @constructor)
 
-(subtype_indication
-  (name
-    (identifier))) @type
-
 (selection
   (identifier) @variable.other.member)
-
-(attribute_identifier) @attribute
-
-(library_namespace) @namespace
-
-(library_clause
-  (logical_name_list
-    (identifier) @namespace))
 
 (use_clause
   (selected_name
     .
     (identifier) @namespace))
 
-(instantiated_unit
-  (name
-    .
-    (identifier) @namespace))
+(_ view: (_) @type)
+(_ type: (_) @type)
+(_ library: (_) @namespace)
+(_ package: (_) @namespace)
+(_ entity: (_) @namespace)
+(_ component: (_) @namespace)
+(_ configuration: (_) @type.parameter)
+(_ architecture: (_) @type.parameter)
+(_ function: (_) @function)
+(_ procedure: (_) @function.method)
+(_ attribute: (_) @attribute)
 
-(function_specification
-  (operator_symbol) @function.builtin)
+(_ view: (name (_)) @type)
+(_ type: (name (_)) @type)
+(_ entity: (name (_)) @namespace)
+(_ component: (name (_)) @namespace)
+(_ configuration: (name (_)) @namespace)
 
-(function_specification
-  (identifier) @function)
-
-(procedure_specification
-  (identifier) @function.method)
-
-(type_declaration
-  (identifier) @type)
-
-(mode_view_declaration
-  (identifier) @type)
-
-(record_mode_view_indication
-  (name
-    (identifier) @type))
-
-(package_declaration
-  (identifier) @namespace)
-
-(package_definition
-  (identifier) @namespace)
-
-(end_package
-  (identifier) @namespace)
-
-(end_package_body
-  (identifier) @namespace)
-
-(entity_declaration
-  (identifier) @namespace)
-
-(end_entity
-  (identifier) @namespace)
-
-(architecture_definition
-  "architecture"
-  (identifier) @type.parameter
-  "of"
-  (name
-    (identifier) @namespace))
-
-(end_architecture
-  (identifier) @type.parameter)
-
-(subprogram_end
-  (identifier) @function)
+(library_type) @type.builtin
 
 (ERROR) @error

--- a/queries/Helix/highlights.scm
+++ b/queries/Helix/highlights.scm
@@ -55,11 +55,11 @@
 ] @keyword
 
 [
-  "all"
-  "others"
+  (ALL)
+  (OTHERS)
   "<>"
-  "default"
-  "open"
+  (DEFAULT)
+  (OPEN)
 ] @constant.builtin
 
 [

--- a/queries/Neovim/highlights.scm
+++ b/queries/Neovim/highlights.scm
@@ -300,24 +300,9 @@
 
 (library_constant_std_logic) @constant.builtin
 
-[
-  (attribute_function)
-  (attribute_impure_function)
-  (attribute_mode_view)
-  (attribute_pure_function)
-  (attribute_range)
-  (attribute_signal)
-  (attribute_subtype)
-  (attribute_type)
-  (attribute_value)
-  (library_attribute)
-] @attribute.builtin
-
 (library_constant) @constant.builtin
 
 (library_function) @function.builtin
-
-(library_type) @type.builtin
 
 (library_constant_boolean) @boolean
 
@@ -339,79 +324,56 @@
   "port" @constructor
   "map" @constructor)
 
-(subtype_indication
-  (name
-    (identifier))) @type
-
 (selection
   (identifier) @variable.member)
-
-(attribute_identifier) @attribute
-
-(library_namespace) @module.builtin
-
-(library_clause
-  (logical_name_list
-    (identifier) @module))
 
 (use_clause
   (selected_name
     .
     (identifier) @module))
 
-(instantiated_unit
-  (name
-    .
-    (identifier) @module))
+(_ view: (_) @type)
+(_ type: (_) @type)
+(_ library: (_) @module)
+(_ package: (_) @module)
+(_ entity: (_) @module)
+(_ component: (_) @module)
+(_ configuration: (_) @property)
+(_ architecture: (_) @property)
+(_ function: (_) @function)
+(_ procedure: (_) @function.method)
+(_ attribute: (_) @attribute)
 
-(function_specification
-  (operator_symbol) @function.builtin)
+(_ view: (name (_)) @type)
+(_ type: (name (_)) @type)
+(_ entity: (name (_)) @module)
+(_ component: (name (_)) @module)
+(_ configuration: (name (_)) @module)
 
-(function_specification
-  (identifier) @function)
+(library_type) @type.builtin
 
-(procedure_specification
-  (identifier) @function.method)
+[
+  (attribute_function)
+  (attribute_impure_function)
+  (attribute_mode_view)
+  (attribute_pure_function)
+  (attribute_range)
+  (attribute_signal)
+  (attribute_subtype)
+  (attribute_type)
+  (attribute_value)
+  (library_attribute)
+] @attribute.builtin
+
+(library_namespace) @module.builtin
+
+(subtype_declaration
+  (identifier) @type.definition)
 
 (type_declaration
   (identifier) @type.definition)
 
 (mode_view_declaration
   (identifier) @type.definition)
-
-(record_mode_view_indication
-  (name
-    (identifier) @type))
-
-(package_declaration
-  (identifier) @module)
-
-(package_definition
-  (identifier) @module)
-
-(end_package
-  (identifier) @module)
-
-(end_package_body
-  (identifier) @module)
-
-(entity_declaration
-  (identifier) @module)
-
-(end_entity
-  (identifier) @module)
-
-(architecture_definition
-  "architecture"
-  (identifier) @property
-  "of"
-  (name
-    (identifier) @module))
-
-(end_architecture
-  (identifier) @property)
-
-(subprogram_end
-  (identifier) @function)
 
 (ERROR) @error

--- a/queries/Neovim/highlights.scm
+++ b/queries/Neovim/highlights.scm
@@ -57,11 +57,11 @@
 ] @keyword
 
 [
-  "all"
-  "others"
+  (ALL)
+  (OTHERS)
   "<>"
-  "default"
-  "open"
+  (DEFAULT)
+  (OPEN)
 ] @constant.builtin
 
 [

--- a/queries/Neovim/highlights.scm
+++ b/queries/Neovim/highlights.scm
@@ -13,193 +13,193 @@
 (identifier) @variable
 
 [
-  (ACCESS)
-  (AFTER)
-  (ALIAS)
-  (ARCHITECTURE)
-  (ARRAY)
-  (ASSUME)
-  (ATTRIBUTE)
-  (BLOCK)
-  (BODY)
-  (COMPONENT)
-  (CONFIGURATION)
-  (CONTEXT)
-  (COVER)
-  (DISCONNECT)
-  (ENTITY)
-  (FAIRNESS)
-  (FILE)
-  (FORCE)
-  (GENERATE)
-  (GENERIC)
-  (GROUP)
-  (LABEL)
-  (LITERAL)
-  (MAP)
-  (NEW)
-  (PACKAGE)
-  (PARAMETER)
-  (PORT)
-  (PROPERTY)
-  (RANGE)
-  (REJECT)
-  (RELEASE)
-  (RESTRICT)
-  (SEQUENCE)
-  (TRANSPORT)
-  (UNAFFECTED)
-  (VIEW)
-  (VPKG)
-  (VMODE)
-  (VPROP)
-  (VUNIT)
+  "access"
+  "after"
+  "alias"
+  "architecture"
+  "array"
+  ; "assume"
+  "attribute"
+  "block"
+  "body"
+  "component"
+  "configuration"
+  "context"
+  ; "cover"
+  "disconnect"
+  "entity"
+  ; "fairness"
+  "file"
+  "force"
+  "generate"
+  "generic"
+  "group"
+  "label"
+  "literal"
+  "map"
+  "new"
+  "package"
+  "parameter"
+  "port"
+  "property"
+  "range"
+  "reject"
+  "release"
+  ; "restrict"
+  "sequence"
+  "transport"
+  "unaffected"
+  "view"
+  ; "vmode"
+  ; "vpkg"
+  ; "vprop"
+  "vunit"
 ] @keyword
 
 [
-  (ALL)
-  (OTHERS)
-  (box)
-  (DEFAULT)
-  (OPEN)
+  "all"
+  "others"
+  "<>"
+  "default"
+  "open"
 ] @constant.builtin
 
 [
-  (IS)
-  (BEGIN)
-  (END)
+  "is"
+  "begin"
+  "end"
 ] @keyword
 
 (parameter_specification
-  (IN) @keyword)
+  "in" @keyword)
 
 [
-  (PROCESS)
-  (WAIT)
-  (ON)
-  (UNTIL)
+  "process"
+  "wait"
+  "on"
+  "until"
 ] @keyword.coroutine
 
 (timeout_clause
-  (FOR) @keyword.coroutine)
+  "for" @keyword.coroutine)
 
 [
-  (FUNCTION)
-  (PROCEDURE)
+  "function"
+  "procedure"
 ] @keyword.function
 
 [
-  (TO)
-  (DOWNTO)
-  (OF)
+  "to"
+  "downto"
+  "of"
 ] @keyword.operator
 
 [
-  (LIBRARY)
-  (USE)
+  "library"
+  "use"
 ] @keyword.import
 
 [
-  (SUBTYPE)
-  (TYPE)
-  (RECORD)
-  (UNITS)
-  (CONSTANT)
-  (SIGNAL)
-  (VARIABLE)
+  "subtype"
+  "type"
+  "record"
+  "units"
+  "constant"
+  "signal"
+  "variable"
 ] @keyword.type
 
 [
-  (PROTECTED)
-  (PRIVATE)
-  (PURE)
-  (IMPURE)
-  (INERTIAL)
-  (POSTPONED)
-  (STRONG)
-  (GUARDED)
-  (OUT)
-  (INOUT)
-  (LINKAGE)
-  (BUFFER)
-  (REGISTER)
-  (BUS)
-  (SHARED)
+  "protected"
+  "private"
+  "pure"
+  "impure"
+  "inertial"
+  "postponed"
+  ; "strong"
+  "guarded"
+  "out"
+  "inout"
+  "linkage"
+  "buffer"
+  "register"
+  "bus"
+  "shared"
 ] @keyword.modifier
 
 (mode
-  (IN) @keyword.modifier)
+  "in" @keyword.modifier)
 
 (force_mode
-  (IN) @keyword.modifier)
+  "in" @keyword.modifier)
 
 [
-  (WHILE)
-  (LOOP)
-  (NEXT)
-  (EXIT)
+  "while"
+  "loop"
+  "next"
+  "exit"
 ] @keyword.repeat
 
 (for_loop
-  (FOR) @keyword.repeat)
+  "for" @keyword.repeat)
 
 (block_configuration
-  (FOR) @keyword)
+  "for" @keyword)
 
 (configuration_specification
-  (FOR) @keyword)
+  "for" @keyword)
 
 (component_configuration
-  (FOR) @keyword)
+  "for" @keyword)
 
 (end_for
-  (FOR) @keyword)
+  "for" @keyword)
 
-(RETURN) @keyword.return
+"return" @keyword.return
 
 [
-  (ASSERT)
-  (REPORT)
-  (SEVERITY)
+  "assert"
+  "report"
+  "severity"
 ] @keyword.debug
 
 [
-  (IF)
-  (THEN)
-  (ELSIF)
-  (CASE)
+  "if"
+  "then"
+  "elsif"
+  "case"
 ] @keyword.conditional
 
 (when_element
-  (WHEN) @keyword.conditional)
+  "when" @keyword.conditional)
 
 (case_generate_alternative
-  (WHEN) @keyword.conditional)
+  "when" @keyword.conditional)
 
 (else_statement
-  (ELSE) @keyword.conditional)
+  "else" @keyword.conditional)
 
 (else_generate
-  (ELSE) @keyword.conditional)
+  "else" @keyword.conditional)
 
 [
-  (WITH)
-  (SELECT)
+  "with"
+  "select"
 ] @keyword.conditional.ternary
 
 (when_expression
-  (WHEN) @keyword.conditional.ternary)
+  "when" @keyword.conditional.ternary)
 
 (else_expression
-  (ELSE) @keyword.conditional.ternary)
+  "else" @keyword.conditional.ternary)
 
 (else_waveform
-  (ELSE) @keyword.conditional.ternary)
+  "else" @keyword.conditional.ternary)
 
 (else_expression_or_unaffected
-  (ELSE) @keyword.conditional.ternary)
+  "else" @keyword.conditional.ternary)
 
-(NULL) @constant.builtin
+"null" @constant.builtin
 
 (user_directive) @keyword.directive
 
@@ -210,22 +210,22 @@
 (error_directive) @keyword.directive
 
 (if_conditional_analysis
-  (IF) @keyword.directive)
+  "if" @keyword.directive)
 
 (if_conditional_analysis
-  (THEN) @keyword.directive)
+  "then" @keyword.directive)
 
 (elsif_conditional_analysis
-  (ELSIF) @keyword.directive)
+  "elsif" @keyword.directive)
 
 (else_conditional_analysis
-  (ELSE) @keyword.directive)
+  "else" @keyword.directive)
 
 (end_conditional_analysis
-  (END) @keyword.directive)
+  "end" @keyword.directive)
 
 (end_conditional_analysis
-  (IF) @keyword.directive)
+  "if" @keyword.directive)
 
 (directive_body) @keyword.directive
 
@@ -332,12 +332,12 @@
 (label) @label
 
 (generic_map_aspect
-  (GENERIC) @constructor
-  (MAP) @constructor)
+  "generic" @constructor
+  "map" @constructor)
 
 (port_map_aspect
-  (PORT) @constructor
-  (MAP) @constructor)
+  "port" @constructor
+  "map" @constructor)
 
 (subtype_indication
   (name
@@ -402,9 +402,9 @@
   (identifier) @module)
 
 (architecture_definition
-  (ARCHITECTURE)
+  "architecture"
   (identifier) @property
-  (OF)
+  "of"
   (name
     (identifier) @module))
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -196,12 +196,20 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "library_namespace"
+          "type": "FIELD",
+          "name": "library",
+          "content": {
+            "type": "SYMBOL",
+            "name": "library_namespace"
+          }
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "library",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         }
       ]
     },
@@ -310,8 +318,12 @@
           "value": "entity"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "entity",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         },
         {
           "type": "SYMBOL",
@@ -468,8 +480,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_identifier"
+              "type": "FIELD",
+              "name": "entity",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_identifier"
+              }
             },
             {
               "type": "BLANK"
@@ -491,8 +507,12 @@
           "value": "configuration"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "configuration",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         },
         {
           "type": "ALIAS",
@@ -504,8 +524,12 @@
           "value": "of"
         },
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "entity",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         },
         {
           "type": "SYMBOL",
@@ -595,8 +619,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_identifier"
+              "type": "FIELD",
+              "name": "configuration",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_identifier"
+              }
             },
             {
               "type": "BLANK"
@@ -618,8 +646,12 @@
           "value": "package"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "package",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         },
         {
           "type": "SYMBOL",
@@ -701,8 +733,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_identifier"
+              "type": "FIELD",
+              "name": "package",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_identifier"
+              }
             },
             {
               "type": "BLANK"
@@ -724,8 +760,12 @@
           "value": "package"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "package",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         },
         {
           "type": "ALIAS",
@@ -780,8 +820,12 @@
           "value": "package"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "package",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         },
         {
           "type": "ALIAS",
@@ -918,8 +962,12 @@
           "value": "architecture"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "architecture",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         },
         {
           "type": "ALIAS",
@@ -931,8 +979,12 @@
           "value": "of"
         },
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "entity",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         },
         {
           "type": "SYMBOL",
@@ -1006,8 +1058,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_identifier"
+              "type": "FIELD",
+              "name": "architecture",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_identifier"
+              }
             },
             {
               "type": "BLANK"
@@ -1038,8 +1094,12 @@
           "value": "body"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "package",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         },
         {
           "type": "SYMBOL",
@@ -1123,8 +1183,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_identifier"
+              "type": "FIELD",
+              "name": "package",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_identifier"
+              }
             },
             {
               "type": "BLANK"
@@ -1823,8 +1887,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_designator"
+              "type": "FIELD",
+              "name": "function",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_designator"
+              }
             },
             {
               "type": "BLANK"
@@ -1840,28 +1908,50 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "PROCEDURE"
-              },
-              "named": false,
-              "value": "procedure"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "PROCEDURE"
+                  },
+                  "named": false,
+                  "value": "procedure"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "procedure",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_designator"
+                  }
+                }
+              ]
             },
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "FUNCTION"
-              },
-              "named": false,
-              "value": "function"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "FUNCTION"
+                  },
+                  "named": false,
+                  "value": "function"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "function",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_designator"
+                  }
+                }
+              ]
             }
           ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_designator"
         },
         {
           "type": "ALIAS",
@@ -1928,8 +2018,12 @@
           "value": "type"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         },
         {
           "type": "CHOICE",
@@ -1976,8 +2070,12 @@
           "value": "subtype"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         },
         {
           "type": "ALIAS",
@@ -2011,8 +2109,12 @@
           "value": "view"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "view",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         },
         {
           "type": "ALIAS",
@@ -2087,8 +2189,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_identifier"
+              "type": "FIELD",
+              "name": "view",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_identifier"
+              }
             },
             {
               "type": "BLANK"
@@ -2437,8 +2543,12 @@
           "value": "component"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "component",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         },
         {
           "type": "CHOICE",
@@ -2568,8 +2678,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_identifier"
+              "type": "FIELD",
+              "name": "component",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_identifier"
+              }
             },
             {
               "type": "BLANK"
@@ -2591,16 +2705,24 @@
           "value": "attribute"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "attribute",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         },
         {
           "type": "STRING",
           "value": ":"
         },
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         },
         {
           "type": "STRING",
@@ -2847,8 +2969,12 @@
           "value": "type"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier"
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          }
         },
         {
           "type": "CHOICE",
@@ -3191,8 +3317,12 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         },
         {
           "type": "ALIAS",
@@ -3284,8 +3414,12 @@
           "value": "of"
         },
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         }
       ]
     },
@@ -3312,7 +3446,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "incomplete_type_mark"
+          "name": "_incomplete_type_mark"
         }
       ]
     },
@@ -3332,8 +3466,12 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         },
         {
           "type": "CHOICE",
@@ -3439,12 +3577,16 @@
         }
       ]
     },
-    "incomplete_type_mark": {
+    "_incomplete_type_mark": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         },
         {
           "type": "SYMBOL",
@@ -4375,8 +4517,12 @@
               "value": "component"
             },
             {
-              "type": "SYMBOL",
-              "name": "name"
+              "type": "FIELD",
+              "name": "component",
+              "content": {
+                "type": "SYMBOL",
+                "name": "name"
+              }
             }
           ]
         },
@@ -4399,8 +4545,12 @@
                   "type": "SEQ",
                   "members": [
                     {
-                      "type": "SYMBOL",
-                      "name": "library_namespace"
+                      "type": "FIELD",
+                      "name": "library",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "library_namespace"
+                      }
                     },
                     {
                       "type": "STRING",
@@ -4414,15 +4564,36 @@
               ]
             },
             {
-              "type": "SYMBOL",
-              "name": "name"
+              "type": "FIELD",
+              "name": "entity",
+              "content": {
+                "type": "SYMBOL",
+                "name": "name"
+              }
             },
             {
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "architecture_identifier"
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "FIELD",
+                      "name": "architecture",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_identifier"
+                      }
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  ]
                 },
                 {
                   "type": "BLANK"
@@ -4444,27 +4615,14 @@
               "value": "configuration"
             },
             {
-              "type": "SYMBOL",
-              "name": "name"
+              "type": "FIELD",
+              "name": "configuration",
+              "content": {
+                "type": "SYMBOL",
+                "name": "name"
+              }
             }
           ]
-        }
-      ]
-    },
-    "architecture_identifier": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_identifier"
-        },
-        {
-          "type": "STRING",
-          "value": ")"
         }
       ]
     },
@@ -7078,7 +7236,7 @@
                 "type": "REPEAT",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "name_selector"
+                  "name": "_name_selector"
                 }
               }
             ]
@@ -7263,7 +7421,7 @@
         }
       ]
     },
-    "name_selector": {
+    "_name_selector": {
       "type": "CHOICE",
       "members": [
         {
@@ -7829,48 +7987,92 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_attribute"
+          "type": "FIELD",
+          "name": "attribute",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_attribute"
+          }
         },
         {
-          "type": "SYMBOL",
-          "name": "attribute_function"
+          "type": "FIELD",
+          "name": "attribute",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_function"
+          }
         },
         {
-          "type": "SYMBOL",
-          "name": "attribute_impure_function"
+          "type": "FIELD",
+          "name": "attribute",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_impure_function"
+          }
         },
         {
-          "type": "SYMBOL",
-          "name": "attribute_mode_view"
+          "type": "FIELD",
+          "name": "attribute",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_mode_view"
+          }
         },
         {
-          "type": "SYMBOL",
-          "name": "attribute_pure_function"
+          "type": "FIELD",
+          "name": "attribute",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_pure_function"
+          }
         },
         {
-          "type": "SYMBOL",
-          "name": "attribute_range"
+          "type": "FIELD",
+          "name": "attribute",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_range"
+          }
         },
         {
-          "type": "SYMBOL",
-          "name": "attribute_signal"
+          "type": "FIELD",
+          "name": "attribute",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_signal"
+          }
         },
         {
-          "type": "SYMBOL",
-          "name": "attribute_subtype"
+          "type": "FIELD",
+          "name": "attribute",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_subtype"
+          }
         },
         {
-          "type": "SYMBOL",
-          "name": "attribute_type"
+          "type": "FIELD",
+          "name": "attribute",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_type"
+          }
         },
         {
-          "type": "SYMBOL",
-          "name": "attribute_value"
+          "type": "FIELD",
+          "name": "attribute",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_value"
+          }
         },
         {
-          "type": "SYMBOL",
-          "name": "library_attribute"
+          "type": "FIELD",
+          "name": "attribute",
+          "content": {
+            "type": "SYMBOL",
+            "name": "library_attribute"
+          }
         }
       ]
     },
@@ -7888,8 +8090,12 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "name"
+                  "type": "FIELD",
+                  "name": "type",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "name"
+                  }
                 },
                 {
                   "type": "REPEAT",
@@ -7901,8 +8107,12 @@
                         "value": ","
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "name"
+                        "type": "FIELD",
+                        "name": "type",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "name"
+                        }
                       }
                     ]
                   }
@@ -7930,8 +8140,12 @@
                   "value": "return"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "name"
+                  "type": "FIELD",
+                  "name": "type",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "name"
+                  }
                 }
               ]
             },
@@ -7994,8 +8208,12 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "_unit"
+                  "type": "FIELD",
+                  "name": "unit",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_unit"
+                  }
                 },
                 {
                   "type": "BLANK"
@@ -9026,8 +9244,12 @@
             "value": "procedure"
           },
           {
-            "type": "SYMBOL",
-            "name": "_designator"
+            "type": "FIELD",
+            "name": "procedure",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_designator"
+            }
           },
           {
             "type": "CHOICE",
@@ -9069,8 +9291,12 @@
           "value": "procedure"
         },
         {
-          "type": "SYMBOL",
-          "name": "_designator"
+          "type": "FIELD",
+          "name": "procedure",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_designator"
+          }
         },
         {
           "type": "CHOICE",
@@ -9130,8 +9356,12 @@
           "value": "function"
         },
         {
-          "type": "SYMBOL",
-          "name": "_designator"
+          "type": "FIELD",
+          "name": "function",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_designator"
+          }
         },
         {
           "type": "CHOICE",
@@ -9193,8 +9423,12 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         }
       ]
     },
@@ -9242,8 +9476,12 @@
           "value": "function"
         },
         {
-          "type": "SYMBOL",
-          "name": "_designator"
+          "type": "FIELD",
+          "name": "function",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_designator"
+          }
         },
         {
           "type": "CHOICE",
@@ -9267,8 +9505,12 @@
           "value": "return"
         },
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         }
       ]
     },
@@ -9596,8 +9838,12 @@
           "value": "view"
         },
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "view",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         },
         {
           "type": "CHOICE",
@@ -9644,8 +9890,12 @@
           "value": "("
         },
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "view",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         },
         {
           "type": "STRING",
@@ -9764,8 +10014,12 @@
           "value": "view"
         },
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "view",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         }
       ]
     },
@@ -9786,8 +10040,12 @@
           "value": "("
         },
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "view",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         },
         {
           "type": "STRING",
@@ -9951,8 +10209,12 @@
           "value": ":"
         },
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          }
         }
       ]
     },
@@ -11876,8 +12138,12 @@
               "value": "entity"
             },
             {
-              "type": "SYMBOL",
-              "name": "name"
+              "type": "FIELD",
+              "name": "entity",
+              "content": {
+                "type": "SYMBOL",
+                "name": "name"
+              }
             },
             {
               "type": "CHOICE",
@@ -11890,8 +12156,12 @@
                       "value": "("
                     },
                     {
-                      "type": "SYMBOL",
-                      "name": "_identifier"
+                      "type": "FIELD",
+                      "name": "architecture",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_identifier"
+                      }
                     },
                     {
                       "type": "STRING",
@@ -11919,8 +12189,12 @@
               "value": "configuration"
             },
             {
-              "type": "SYMBOL",
-              "name": "name"
+              "type": "FIELD",
+              "name": "configuration",
+              "content": {
+                "type": "SYMBOL",
+                "name": "name"
+              }
             }
           ]
         },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -254,13 +254,8 @@
                     "name": "_identifier"
                   },
                   {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "ALL"
-                    },
-                    "named": false,
-                    "value": "all"
+                    "type": "SYMBOL",
+                    "name": "ALL"
                   }
                 ]
               }
@@ -7802,13 +7797,8 @@
             ]
           },
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "OPEN"
-            },
-            "named": false,
-            "value": "open"
+            "type": "SYMBOL",
+            "name": "OPEN"
           }
         ]
       }
@@ -7985,13 +7975,8 @@
           "name": "operator_symbol"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ALL"
-          },
-          "named": false,
-          "value": "all"
+          "type": "SYMBOL",
+          "name": "ALL"
         }
       ]
     },
@@ -8228,13 +8213,8 @@
           "name": "_range"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "OTHERS"
-          },
-          "named": false,
-          "value": "others"
+          "type": "SYMBOL",
+          "name": "OTHERS"
         },
         {
           "type": "SYMBOL",
@@ -9375,13 +9355,8 @@
           "value": "("
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "DEFAULT"
-          },
-          "named": false,
-          "value": "default"
+          "type": "SYMBOL",
+          "name": "DEFAULT"
         },
         {
           "type": "STRING",
@@ -10010,22 +9985,12 @@
           ]
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "OTHERS"
-          },
-          "named": false,
-          "value": "others"
+          "type": "SYMBOL",
+          "name": "OTHERS"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ALL"
-          },
-          "named": false,
-          "value": "all"
+          "type": "SYMBOL",
+          "name": "ALL"
         }
       ]
     },
@@ -10260,22 +10225,12 @@
           ]
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "OTHERS"
-          },
-          "named": false,
-          "value": "others"
+          "type": "SYMBOL",
+          "name": "OTHERS"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ALL"
-          },
-          "named": false,
-          "value": "all"
+          "type": "SYMBOL",
+          "name": "ALL"
         }
       ]
     },
@@ -10344,13 +10299,8 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "OPEN"
-                  },
-                  "named": false,
-                  "value": "open"
+                  "type": "SYMBOL",
+                  "name": "OPEN"
                 },
                 {
                   "type": "SYMBOL",
@@ -11629,13 +11579,8 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ALL"
-          },
-          "named": false,
-          "value": "all"
+          "type": "SYMBOL",
+          "name": "ALL"
         },
         {
           "type": "SYMBOL",
@@ -11847,22 +11792,12 @@
           ]
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "OTHERS"
-          },
-          "named": false,
-          "value": "others"
+          "type": "SYMBOL",
+          "name": "OTHERS"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ALL"
-          },
-          "named": false,
-          "value": "all"
+          "type": "SYMBOL",
+          "name": "ALL"
         }
       ]
     },
@@ -11990,13 +11925,8 @@
           ]
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "OPEN"
-          },
-          "named": false,
-          "value": "open"
+          "type": "SYMBOL",
+          "name": "OPEN"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -256,13 +256,8 @@
                   {
                     "type": "ALIAS",
                     "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "ALL"
-                      },
-                      "named": false,
-                      "value": "all"
+                      "type": "SYMBOL",
+                      "name": "ALL"
                     },
                     "named": false,
                     "value": "all"
@@ -921,13 +916,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ARCHITECTURE"
-            },
-            "named": false,
-            "value": "architecture"
+            "type": "SYMBOL",
+            "name": "ARCHITECTURE"
           },
           "named": false,
           "value": "architecture"
@@ -1006,13 +996,8 @@
             {
               "type": "ALIAS",
               "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "ARCHITECTURE"
-                },
-                "named": false,
-                "value": "architecture"
+                "type": "SYMBOL",
+                "name": "ARCHITECTURE"
               },
               "named": false,
               "value": "architecture"
@@ -2394,13 +2379,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ALIAS"
-            },
-            "named": false,
-            "value": "alias"
+            "type": "SYMBOL",
+            "name": "ALIAS"
           },
           "named": false,
           "value": "alias"
@@ -2700,13 +2680,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "AFTER"
-            },
-            "named": false,
-            "value": "after"
+            "type": "SYMBOL",
+            "name": "AFTER"
           },
           "named": false,
           "value": "after"
@@ -3080,13 +3055,8 @@
             {
               "type": "ALIAS",
               "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "ARRAY"
-                },
-                "named": false,
-                "value": "array"
+                "type": "SYMBOL",
+                "name": "ARRAY"
               },
               "named": false,
               "value": "array"
@@ -3124,13 +3094,8 @@
             {
               "type": "ALIAS",
               "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "ARRAY"
-                },
-                "named": false,
-                "value": "array"
+                "type": "SYMBOL",
+                "name": "ARRAY"
               },
               "named": false,
               "value": "array"
@@ -3260,13 +3225,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ACCESS"
-            },
-            "named": false,
-            "value": "access"
+            "type": "SYMBOL",
+            "name": "ACCESS"
           },
           "named": false,
           "value": "access"
@@ -3295,13 +3255,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ACCESS"
-            },
-            "named": false,
-            "value": "access"
+            "type": "SYMBOL",
+            "name": "ACCESS"
           },
           "named": false,
           "value": "access"
@@ -5030,13 +4985,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ASSERT"
-            },
-            "named": false,
-            "value": "assert"
+            "type": "SYMBOL",
+            "name": "ASSERT"
           },
           "named": false,
           "value": "assert"
@@ -8037,13 +7987,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ALL"
-            },
-            "named": false,
-            "value": "all"
+            "type": "SYMBOL",
+            "name": "ALL"
           },
           "named": false,
           "value": "all"
@@ -10076,13 +10021,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ALL"
-            },
-            "named": false,
-            "value": "all"
+            "type": "SYMBOL",
+            "name": "ALL"
           },
           "named": false,
           "value": "all"
@@ -10121,13 +10061,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ARCHITECTURE"
-            },
-            "named": false,
-            "value": "architecture"
+            "type": "SYMBOL",
+            "name": "ARCHITECTURE"
           },
           "named": false,
           "value": "architecture"
@@ -10336,13 +10271,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ALL"
-            },
-            "named": false,
-            "value": "all"
+            "type": "SYMBOL",
+            "name": "ALL"
           },
           "named": false,
           "value": "all"
@@ -11018,13 +10948,8 @@
                 {
                   "type": "ALIAS",
                   "content": {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "AFTER"
-                    },
-                    "named": false,
-                    "value": "after"
+                    "type": "SYMBOL",
+                    "name": "AFTER"
                   },
                   "named": false,
                   "value": "after"
@@ -11706,13 +11631,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ALL"
-            },
-            "named": false,
-            "value": "all"
+            "type": "SYMBOL",
+            "name": "ALL"
           },
           "named": false,
           "value": "all"
@@ -11938,13 +11858,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ALL"
-            },
-            "named": false,
-            "value": "all"
+            "type": "SYMBOL",
+            "name": "ALL"
           },
           "named": false,
           "value": "all"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -69,8 +69,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "LIBRARY"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "LIBRARY"
+          },
+          "named": false,
+          "value": "library"
         },
         {
           "type": "SYMBOL",
@@ -86,8 +91,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "USE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "USE"
+          },
+          "named": false,
+          "value": "use"
         },
         {
           "type": "SYMBOL",
@@ -119,8 +129,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "CONTEXT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "CONTEXT"
+          },
+          "named": false,
+          "value": "context"
         },
         {
           "type": "SYMBOL",
@@ -219,8 +234,18 @@
                     "name": "_identifier"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "ALL"
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "ALL"
+                      },
+                      "named": false,
+                      "value": "all"
+                    },
+                    "named": false,
+                    "value": "all"
                   }
                 ]
               }
@@ -266,8 +291,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ENTITY"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ENTITY"
+          },
+          "named": false,
+          "value": "entity"
         },
         {
           "type": "SYMBOL",
@@ -303,8 +333,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "CHOICE",
@@ -343,8 +378,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "PORT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PORT"
+          },
+          "named": false,
+          "value": "port"
         },
         {
           "type": "STRING",
@@ -368,8 +408,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "BEGIN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "BEGIN"
+          },
+          "named": false,
+          "value": "begin"
         },
         {
           "type": "REPEAT",
@@ -384,15 +429,25 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "ENTITY"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "ENTITY"
+              },
+              "named": false,
+              "value": "entity"
             },
             {
               "type": "BLANK"
@@ -417,16 +472,26 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "CONFIGURATION"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "CONFIGURATION"
+          },
+          "named": false,
+          "value": "configuration"
         },
         {
           "type": "SYMBOL",
           "name": "_identifier"
         },
         {
-          "type": "SYMBOL",
-          "name": "OF"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "OF"
+          },
+          "named": false,
+          "value": "of"
         },
         {
           "type": "SYMBOL",
@@ -454,8 +519,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "REPEAT",
@@ -486,15 +556,25 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "CONFIGURATION"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "CONFIGURATION"
+              },
+              "named": false,
+              "value": "configuration"
             },
             {
               "type": "BLANK"
@@ -519,8 +599,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "PACKAGE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PACKAGE"
+          },
+          "named": false,
+          "value": "package"
         },
         {
           "type": "SYMBOL",
@@ -544,8 +629,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "CHOICE",
@@ -572,15 +662,25 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "PACKAGE"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "PACKAGE"
+              },
+              "named": false,
+              "value": "package"
             },
             {
               "type": "BLANK"
@@ -605,20 +705,35 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "PACKAGE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PACKAGE"
+          },
+          "named": false,
+          "value": "package"
         },
         {
           "type": "SYMBOL",
           "name": "_identifier"
         },
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
-          "type": "SYMBOL",
-          "name": "NEW"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "NEW"
+          },
+          "named": false,
+          "value": "new"
         },
         {
           "type": "SYMBOL",
@@ -646,20 +761,35 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "PACKAGE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PACKAGE"
+          },
+          "named": false,
+          "value": "package"
         },
         {
           "type": "SYMBOL",
           "name": "_identifier"
         },
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
-          "type": "SYMBOL",
-          "name": "NEW"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "NEW"
+          },
+          "named": false,
+          "value": "new"
         },
         {
           "type": "SYMBOL",
@@ -675,8 +805,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "CONTEXT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "CONTEXT"
+          },
+          "named": false,
+          "value": "context"
         },
         {
           "type": "SYMBOL",
@@ -700,8 +835,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "REPEAT",
@@ -716,15 +856,25 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "CONTEXT"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "CONTEXT"
+              },
+              "named": false,
+              "value": "context"
             },
             {
               "type": "BLANK"
@@ -749,16 +899,31 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ARCHITECTURE"
+          "type": "ALIAS",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ARCHITECTURE"
+            },
+            "named": false,
+            "value": "architecture"
+          },
+          "named": false,
+          "value": "architecture"
         },
         {
           "type": "SYMBOL",
           "name": "_identifier"
         },
         {
-          "type": "SYMBOL",
-          "name": "OF"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "OF"
+          },
+          "named": false,
+          "value": "of"
         },
         {
           "type": "SYMBOL",
@@ -786,8 +951,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "REPEAT",
@@ -802,15 +972,30 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "ARCHITECTURE"
+              "type": "ALIAS",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "ARCHITECTURE"
+                },
+                "named": false,
+                "value": "architecture"
+              },
+              "named": false,
+              "value": "architecture"
             },
             {
               "type": "BLANK"
@@ -835,12 +1020,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "PACKAGE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PACKAGE"
+          },
+          "named": false,
+          "value": "package"
         },
         {
-          "type": "SYMBOL",
-          "name": "BODY"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "BODY"
+          },
+          "named": false,
+          "value": "body"
         },
         {
           "type": "SYMBOL",
@@ -864,8 +1059,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "REPEAT",
@@ -880,8 +1080,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
           "type": "CHOICE",
@@ -890,12 +1095,22 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "PACKAGE"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "PACKAGE"
+                  },
+                  "named": false,
+                  "value": "package"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "BODY"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "BODY"
+                  },
+                  "named": false,
+                  "value": "body"
                 }
               ]
             },
@@ -1544,8 +1759,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "REPEAT",
@@ -1560,8 +1780,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
           "type": "CHOICE",
@@ -1570,12 +1795,22 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "PROCEDURE"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "PROCEDURE"
+                  },
+                  "named": false,
+                  "value": "procedure"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "FUNCTION"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "FUNCTION"
+                  },
+                  "named": false,
+                  "value": "function"
                 }
               ]
             },
@@ -1605,12 +1840,22 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "PROCEDURE"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "PROCEDURE"
+              },
+              "named": false,
+              "value": "procedure"
             },
             {
-              "type": "SYMBOL",
-              "name": "FUNCTION"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "FUNCTION"
+              },
+              "named": false,
+              "value": "function"
             }
           ]
         },
@@ -1619,12 +1864,22 @@
           "name": "_designator"
         },
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
-          "type": "SYMBOL",
-          "name": "NEW"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "NEW"
+          },
+          "named": false,
+          "value": "new"
         },
         {
           "type": "SYMBOL",
@@ -1664,8 +1919,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "TYPE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "TYPE"
+          },
+          "named": false,
+          "value": "type"
         },
         {
           "type": "SYMBOL",
@@ -1678,8 +1938,13 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "IS"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "IS"
+                  },
+                  "named": false,
+                  "value": "is"
                 },
                 {
                   "type": "SYMBOL",
@@ -1702,16 +1967,26 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "SUBTYPE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "SUBTYPE"
+          },
+          "named": false,
+          "value": "subtype"
         },
         {
           "type": "SYMBOL",
           "name": "_identifier"
         },
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "SYMBOL",
@@ -1727,16 +2002,26 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "VIEW"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "VIEW"
+          },
+          "named": false,
+          "value": "view"
         },
         {
           "type": "SYMBOL",
           "name": "_identifier"
         },
         {
-          "type": "SYMBOL",
-          "name": "OF"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "OF"
+          },
+          "named": false,
+          "value": "of"
         },
         {
           "type": "SYMBOL",
@@ -1760,8 +2045,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "REPEAT",
@@ -1776,12 +2066,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
-          "type": "SYMBOL",
-          "name": "VIEW"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "VIEW"
+          },
+          "named": false,
+          "value": "view"
         },
         {
           "type": "CHOICE",
@@ -1801,8 +2101,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "CONSTANT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "CONSTANT"
+          },
+          "named": false,
+          "value": "constant"
         },
         {
           "type": "SYMBOL",
@@ -1838,8 +2143,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "SIGNAL"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "SIGNAL"
+          },
+          "named": false,
+          "value": "signal"
         },
         {
           "type": "SYMBOL",
@@ -1887,12 +2197,22 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "REGISTER"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "REGISTER"
+          },
+          "named": false,
+          "value": "register"
         },
         {
-          "type": "SYMBOL",
-          "name": "BUS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "BUS"
+          },
+          "named": false,
+          "value": "bus"
         }
       ]
     },
@@ -1903,8 +2223,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "SHARED"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "SHARED"
+              },
+              "named": false,
+              "value": "shared"
             },
             {
               "type": "BLANK"
@@ -1912,8 +2237,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "VARIABLE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "VARIABLE"
+          },
+          "named": false,
+          "value": "variable"
         },
         {
           "type": "SYMBOL",
@@ -1974,8 +2304,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "FILE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FILE"
+          },
+          "named": false,
+          "value": "file"
         },
         {
           "type": "SYMBOL",
@@ -2011,8 +2346,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "FILE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FILE"
+          },
+          "named": false,
+          "value": "file"
         },
         {
           "type": "SYMBOL",
@@ -2032,8 +2372,18 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ALIAS"
+          "type": "ALIAS",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ALIAS"
+            },
+            "named": false,
+            "value": "alias"
+          },
+          "named": false,
+          "value": "alias"
         },
         {
           "type": "SYMBOL",
@@ -2061,8 +2411,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "SYMBOL",
@@ -2078,8 +2433,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "COMPONENT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "COMPONENT"
+          },
+          "named": false,
+          "value": "component"
         },
         {
           "type": "SYMBOL",
@@ -2114,8 +2474,13 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "IS"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "IS"
+              },
+              "named": false,
+              "value": "is"
             },
             {
               "type": "CHOICE",
@@ -2179,15 +2544,25 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "COMPONENT"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "COMPONENT"
+              },
+              "named": false,
+              "value": "component"
             },
             {
               "type": "BLANK"
@@ -2212,8 +2587,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ATTRIBUTE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ATTRIBUTE"
+          },
+          "named": false,
+          "value": "attribute"
         },
         {
           "type": "SYMBOL",
@@ -2237,24 +2617,39 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ATTRIBUTE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ATTRIBUTE"
+          },
+          "named": false,
+          "value": "attribute"
         },
         {
           "type": "SYMBOL",
           "name": "_attribute_designator"
         },
         {
-          "type": "SYMBOL",
-          "name": "OF"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "OF"
+          },
+          "named": false,
+          "value": "of"
         },
         {
           "type": "SYMBOL",
           "name": "entity_specification"
         },
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "SYMBOL",
@@ -2270,16 +2665,31 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "DISCONNECT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "DISCONNECT"
+          },
+          "named": false,
+          "value": "disconnect"
         },
         {
           "type": "SYMBOL",
           "name": "guarded_signal_specification"
         },
         {
-          "type": "SYMBOL",
-          "name": "AFTER"
+          "type": "ALIAS",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "AFTER"
+            },
+            "named": false,
+            "value": "after"
+          },
+          "named": false,
+          "value": "after"
         },
         {
           "type": "SYMBOL",
@@ -2295,16 +2705,26 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "GROUP"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "GROUP"
+          },
+          "named": false,
+          "value": "group"
         },
         {
           "type": "SYMBOL",
           "name": "_identifier"
         },
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "STRING",
@@ -2328,8 +2748,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "GROUP"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "GROUP"
+          },
+          "named": false,
+          "value": "group"
         },
         {
           "type": "SYMBOL",
@@ -2365,8 +2790,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "PRIVATE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PRIVATE"
+          },
+          "named": false,
+          "value": "private"
         },
         {
           "type": "SYMBOL",
@@ -2391,12 +2821,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "TYPE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "TYPE"
+          },
+          "named": false,
+          "value": "type"
         },
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "SYMBOL",
@@ -2408,8 +2848,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "TYPE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "TYPE"
+          },
+          "named": false,
+          "value": "type"
         },
         {
           "type": "SYMBOL",
@@ -2422,8 +2867,13 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "IS"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "IS"
+                  },
+                  "named": false,
+                  "value": "is"
                 },
                 {
                   "type": "SYMBOL",
@@ -2480,12 +2930,22 @@
       ]
     },
     "private_incomplete_type_definition": {
-      "type": "SYMBOL",
-      "name": "PRIVATE"
+      "type": "ALIAS",
+      "content": {
+        "type": "SYMBOL",
+        "name": "PRIVATE"
+      },
+      "named": false,
+      "value": "private"
     },
     "scalar_incomplete_type_definition": {
-      "type": "SYMBOL",
-      "name": "box"
+      "type": "ALIAS",
+      "content": {
+        "type": "SYMBOL",
+        "name": "box"
+      },
+      "named": false,
+      "value": "<>"
     },
     "discrete_incomplete_type_definition": {
       "type": "SEQ",
@@ -2495,8 +2955,13 @@
           "value": "("
         },
         {
-          "type": "SYMBOL",
-          "name": "box"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "box"
+          },
+          "named": false,
+          "value": "<>"
         },
         {
           "type": "STRING",
@@ -2508,12 +2973,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "RANGE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "RANGE"
+          },
+          "named": false,
+          "value": "range"
         },
         {
-          "type": "SYMBOL",
-          "name": "box"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "box"
+          },
+          "named": false,
+          "value": "<>"
         }
       ]
     },
@@ -2521,12 +2996,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "UNITS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "UNITS"
+          },
+          "named": false,
+          "value": "units"
         },
         {
-          "type": "SYMBOL",
-          "name": "box"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "box"
+          },
+          "named": false,
+          "value": "<>"
         }
       ]
     },
@@ -2534,20 +3019,35 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "RANGE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "RANGE"
+          },
+          "named": false,
+          "value": "range"
         },
         {
-          "type": "SYMBOL",
-          "name": "box"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "box"
+          },
+          "named": false,
+          "value": "<>"
         },
         {
           "type": "STRING",
           "value": "."
         },
         {
-          "type": "SYMBOL",
-          "name": "box"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "box"
+          },
+          "named": false,
+          "value": "<>"
         }
       ]
     },
@@ -2558,8 +3058,18 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "ARRAY"
+              "type": "ALIAS",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "ARRAY"
+                },
+                "named": false,
+                "value": "array"
+              },
+              "named": false,
+              "value": "array"
             },
             {
               "type": "STRING",
@@ -2574,8 +3084,13 @@
               "value": ")"
             },
             {
-              "type": "SYMBOL",
-              "name": "OF"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "OF"
+              },
+              "named": false,
+              "value": "of"
             },
             {
               "type": "SYMBOL",
@@ -2587,16 +3102,31 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "ARRAY"
+              "type": "ALIAS",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "ARRAY"
+                },
+                "named": false,
+                "value": "array"
+              },
+              "named": false,
+              "value": "array"
             },
             {
               "type": "SYMBOL",
               "name": "index_constraint"
             },
             {
-              "type": "SYMBOL",
-              "name": "OF"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "OF"
+              },
+              "named": false,
+              "value": "of"
             },
             {
               "type": "SYMBOL",
@@ -2685,12 +3215,22 @@
           "name": "name"
         },
         {
-          "type": "SYMBOL",
-          "name": "RANGE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "RANGE"
+          },
+          "named": false,
+          "value": "range"
         },
         {
-          "type": "SYMBOL",
-          "name": "box"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "box"
+          },
+          "named": false,
+          "value": "<>"
         }
       ]
     },
@@ -2698,8 +3238,18 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ACCESS"
+          "type": "ALIAS",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ACCESS"
+            },
+            "named": false,
+            "value": "access"
+          },
+          "named": false,
+          "value": "access"
         },
         {
           "type": "SYMBOL",
@@ -2723,8 +3273,18 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ACCESS"
+          "type": "ALIAS",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ACCESS"
+            },
+            "named": false,
+            "value": "access"
+          },
+          "named": false,
+          "value": "access"
         },
         {
           "type": "SYMBOL",
@@ -2736,12 +3296,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "FILE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FILE"
+          },
+          "named": false,
+          "value": "file"
         },
         {
-          "type": "SYMBOL",
-          "name": "OF"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "OF"
+          },
+          "named": false,
+          "value": "of"
         },
         {
           "type": "SYMBOL",
@@ -2753,12 +3323,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "FILE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FILE"
+          },
+          "named": false,
+          "value": "file"
         },
         {
-          "type": "SYMBOL",
-          "name": "OF"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "OF"
+          },
+          "named": false,
+          "value": "of"
         },
         {
           "type": "SYMBOL",
@@ -2906,8 +3486,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "BEGIN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "BEGIN"
+          },
+          "named": false,
+          "value": "begin"
         },
         {
           "type": "REPEAT",
@@ -2922,8 +3507,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "BEGIN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "BEGIN"
+          },
+          "named": false,
+          "value": "begin"
         },
         {
           "type": "REPEAT",
@@ -2964,8 +3554,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "GENERATE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "GENERATE"
+          },
+          "named": false,
+          "value": "generate"
         },
         {
           "type": "REPEAT",
@@ -2980,8 +3575,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "GENERATE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "GENERATE"
+          },
+          "named": false,
+          "value": "generate"
         },
         {
           "type": "REPEAT",
@@ -2999,8 +3599,13 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "WHEN"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "WHEN"
+            },
+            "named": false,
+            "value": "when"
           },
           {
             "type": "CHOICE",
@@ -3087,8 +3692,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "BEGIN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "BEGIN"
+          },
+          "named": false,
+          "value": "begin"
         },
         {
           "type": "REPEAT",
@@ -3103,8 +3713,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
           "type": "CHOICE",
@@ -3283,8 +3898,13 @@
           "name": "label_declaration"
         },
         {
-          "type": "SYMBOL",
-          "name": "BLOCK"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "BLOCK"
+          },
+          "named": false,
+          "value": "block"
         },
         {
           "type": "CHOICE",
@@ -3348,8 +3968,13 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "IS"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "IS"
+              },
+              "named": false,
+              "value": "is"
             },
             {
               "type": "CHOICE",
@@ -3566,12 +4191,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
-          "type": "SYMBOL",
-          "name": "BLOCK"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "BLOCK"
+          },
+          "named": false,
+          "value": "block"
         },
         {
           "type": "CHOICE",
@@ -3603,8 +4238,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "BLOCK"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "BLOCK"
+          },
+          "named": false,
+          "value": "block"
         },
         {
           "type": "CHOICE",
@@ -3639,8 +4279,13 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "IS"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "IS"
+              },
+              "named": false,
+              "value": "is"
             },
             {
               "type": "REPEAT",
@@ -3751,8 +4396,13 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "COMPONENT"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "COMPONENT"
+              },
+              "named": false,
+              "value": "component"
             },
             {
               "type": "SYMBOL",
@@ -3764,8 +4414,13 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "ENTITY"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "ENTITY"
+              },
+              "named": false,
+              "value": "entity"
             },
             {
               "type": "CHOICE",
@@ -3810,8 +4465,13 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "CONFIGURATION"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "CONFIGURATION"
+              },
+              "named": false,
+              "value": "configuration"
             },
             {
               "type": "SYMBOL",
@@ -3857,8 +4517,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "POSTPONED"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "POSTPONED"
+              },
+              "named": false,
+              "value": "postponed"
             },
             {
               "type": "BLANK"
@@ -3866,8 +4531,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "PROCESS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PROCESS"
+          },
+          "named": false,
+          "value": "process"
         },
         {
           "type": "CHOICE",
@@ -3931,8 +4601,13 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "IS"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "IS"
+              },
+              "named": false,
+              "value": "is"
             },
             {
               "type": "REPEAT",
@@ -3961,15 +4636,25 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "POSTPONED"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "POSTPONED"
+              },
+              "named": false,
+              "value": "postponed"
             },
             {
               "type": "BLANK"
@@ -3977,8 +4662,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "PROCESS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PROCESS"
+          },
+          "named": false,
+          "value": "process"
         },
         {
           "type": "CHOICE",
@@ -4002,8 +4692,13 @@
           "name": "label_declaration"
         },
         {
-          "type": "SYMBOL",
-          "name": "CASE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "CASE"
+          },
+          "named": false,
+          "value": "case"
         },
         {
           "type": "SYMBOL",
@@ -4027,8 +4722,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "GENERATE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "GENERATE"
+          },
+          "named": false,
+          "value": "generate"
         },
         {
           "type": "REPEAT1",
@@ -4108,8 +4808,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IF"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IF"
+          },
+          "named": false,
+          "value": "if"
         },
         {
           "type": "CHOICE",
@@ -4137,8 +4842,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ELSIF"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ELSIF"
+          },
+          "named": false,
+          "value": "elsif"
         },
         {
           "type": "CHOICE",
@@ -4166,8 +4876,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ELSE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ELSE"
+          },
+          "named": false,
+          "value": "else"
         },
         {
           "type": "CHOICE",
@@ -4191,12 +4906,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
-          "type": "SYMBOL",
-          "name": "GENERATE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "GENERATE"
+          },
+          "named": false,
+          "value": "generate"
         },
         {
           "type": "CHOICE",
@@ -4256,8 +4981,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "POSTPONED"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "POSTPONED"
+              },
+              "named": false,
+              "value": "postponed"
             },
             {
               "type": "BLANK"
@@ -4278,8 +5008,18 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ASSERT"
+          "type": "ALIAS",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ASSERT"
+            },
+            "named": false,
+            "value": "assert"
+          },
+          "named": false,
+          "value": "assert"
         },
         {
           "type": "SYMBOL",
@@ -4315,8 +5055,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "REPORT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "REPORT"
+          },
+          "named": false,
+          "value": "report"
         },
         {
           "type": "SYMBOL",
@@ -4328,8 +5073,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "SEVERITY"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "SEVERITY"
+          },
+          "named": false,
+          "value": "severity"
         },
         {
           "type": "SYMBOL",
@@ -4374,8 +5124,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "CASE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "CASE"
+          },
+          "named": false,
+          "value": "case"
         },
         {
           "type": "CHOICE",
@@ -4399,8 +5154,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "REPEAT1",
@@ -4415,12 +5175,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
-          "type": "SYMBOL",
-          "name": "CASE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "CASE"
+          },
+          "named": false,
+          "value": "case"
         },
         {
           "type": "CHOICE",
@@ -4464,8 +5234,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "EXIT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "EXIT"
+          },
+          "named": false,
+          "value": "exit"
         },
         {
           "type": "CHOICE",
@@ -4501,8 +5276,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "WHEN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "WHEN"
+          },
+          "named": false,
+          "value": "when"
         },
         {
           "type": "SYMBOL",
@@ -4562,16 +5342,26 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IF"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IF"
+          },
+          "named": false,
+          "value": "if"
         },
         {
           "type": "SYMBOL",
           "name": "_expression"
         },
         {
-          "type": "SYMBOL",
-          "name": "THEN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "THEN"
+          },
+          "named": false,
+          "value": "then"
         },
         {
           "type": "CHOICE",
@@ -4603,16 +5393,26 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ELSIF"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ELSIF"
+          },
+          "named": false,
+          "value": "elsif"
         },
         {
           "type": "SYMBOL",
           "name": "_expression"
         },
         {
-          "type": "SYMBOL",
-          "name": "THEN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "THEN"
+          },
+          "named": false,
+          "value": "then"
         },
         {
           "type": "CHOICE",
@@ -4632,8 +5432,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ELSE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ELSE"
+          },
+          "named": false,
+          "value": "else"
         },
         {
           "type": "CHOICE",
@@ -4653,12 +5458,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
-          "type": "SYMBOL",
-          "name": "IF"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IF"
+          },
+          "named": false,
+          "value": "if"
         },
         {
           "type": "CHOICE",
@@ -4732,8 +5547,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "LOOP"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "LOOP"
+          },
+          "named": false,
+          "value": "loop"
         },
         {
           "type": "REPEAT",
@@ -4748,12 +5568,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
-          "type": "SYMBOL",
-          "name": "LOOP"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "LOOP"
+          },
+          "named": false,
+          "value": "loop"
         },
         {
           "type": "CHOICE",
@@ -4785,8 +5615,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "NEXT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "NEXT"
+          },
+          "named": false,
+          "value": "next"
         },
         {
           "type": "CHOICE",
@@ -4834,8 +5669,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "NULL"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "NULL"
+          },
+          "named": false,
+          "value": "null"
         },
         {
           "type": "STRING",
@@ -4887,8 +5727,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "POSTPONED"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "POSTPONED"
+              },
+              "named": false,
+              "value": "postponed"
             },
             {
               "type": "BLANK"
@@ -4961,8 +5806,13 @@
               ]
             },
             {
-              "type": "SYMBOL",
-              "name": "RETURN"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "RETURN"
+              },
+              "named": false,
+              "value": "return"
             },
             {
               "type": "CHOICE",
@@ -4998,8 +5848,13 @@
               ]
             },
             {
-              "type": "SYMBOL",
-              "name": "RETURN"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "RETURN"
+              },
+              "named": false,
+              "value": "return"
             },
             {
               "type": "SYMBOL",
@@ -5118,8 +5973,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "POSTPONED"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "POSTPONED"
+              },
+              "named": false,
+              "value": "postponed"
             },
             {
               "type": "BLANK"
@@ -5138,8 +5998,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "GUARDED"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "GUARDED"
+              },
+              "named": false,
+              "value": "guarded"
             },
             {
               "type": "BLANK"
@@ -5192,8 +6057,13 @@
           "name": "signal_assignment"
         },
         {
-          "type": "SYMBOL",
-          "name": "FORCE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FORCE"
+          },
+          "named": false,
+          "value": "force"
         },
         {
           "type": "CHOICE",
@@ -5241,8 +6111,13 @@
           "name": "signal_assignment"
         },
         {
-          "type": "SYMBOL",
-          "name": "RELEASE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "RELEASE"
+          },
+          "named": false,
+          "value": "release"
         },
         {
           "type": "CHOICE",
@@ -5326,8 +6201,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "POSTPONED"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "POSTPONED"
+              },
+              "named": false,
+              "value": "postponed"
             },
             {
               "type": "BLANK"
@@ -5346,8 +6226,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "GUARDED"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "GUARDED"
+              },
+              "named": false,
+              "value": "guarded"
             },
             {
               "type": "BLANK"
@@ -5444,8 +6329,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "POSTPONED"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "POSTPONED"
+              },
+              "named": false,
+              "value": "postponed"
             },
             {
               "type": "BLANK"
@@ -5468,8 +6358,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "GUARDED"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "GUARDED"
+              },
+              "named": false,
+              "value": "guarded"
             },
             {
               "type": "BLANK"
@@ -5526,8 +6421,13 @@
           "name": "signal_assignment"
         },
         {
-          "type": "SYMBOL",
-          "name": "FORCE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FORCE"
+          },
+          "named": false,
+          "value": "force"
         },
         {
           "type": "CHOICE",
@@ -5592,8 +6492,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "WITH"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "WITH"
+          },
+          "named": false,
+          "value": "with"
         },
         {
           "type": "SYMBOL",
@@ -5605,8 +6510,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "SELECT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "SELECT"
+          },
+          "named": false,
+          "value": "select"
         },
         {
           "type": "CHOICE",
@@ -5642,8 +6552,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "WAIT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "WAIT"
+          },
+          "named": false,
+          "value": "wait"
         },
         {
           "type": "CHOICE",
@@ -5720,8 +6635,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ELSE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ELSE"
+          },
+          "named": false,
+          "value": "else"
         },
         {
           "type": "SYMBOL",
@@ -6428,8 +7348,13 @@
           "value": "<<"
         },
         {
-          "type": "SYMBOL",
-          "name": "CONSTANT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "CONSTANT"
+          },
+          "named": false,
+          "value": "constant"
         },
         {
           "type": "SYMBOL",
@@ -6457,8 +7382,13 @@
           "value": "<<"
         },
         {
-          "type": "SYMBOL",
-          "name": "SIGNAL"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "SIGNAL"
+          },
+          "named": false,
+          "value": "signal"
         },
         {
           "type": "SYMBOL",
@@ -6486,8 +7416,13 @@
           "value": "<<"
         },
         {
-          "type": "SYMBOL",
-          "name": "VARIABLE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "VARIABLE"
+          },
+          "named": false,
+          "value": "variable"
         },
         {
           "type": "SYMBOL",
@@ -6688,12 +7623,22 @@
                 ]
               },
               {
-                "type": "SYMBOL",
-                "name": "PARAMETER"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "PARAMETER"
+                },
+                "named": false,
+                "value": "parameter"
               },
               {
-                "type": "SYMBOL",
-                "name": "MAP"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "MAP"
+                },
+                "named": false,
+                "value": "map"
               },
               {
                 "type": "SYMBOL",
@@ -6721,12 +7666,22 @@
                             "type": "SEQ",
                             "members": [
                               {
-                                "type": "SYMBOL",
-                                "name": "PARAMETER"
+                                "type": "ALIAS",
+                                "content": {
+                                  "type": "SYMBOL",
+                                  "name": "PARAMETER"
+                                },
+                                "named": false,
+                                "value": "parameter"
                               },
                               {
-                                "type": "SYMBOL",
-                                "name": "MAP"
+                                "type": "ALIAS",
+                                "content": {
+                                  "type": "SYMBOL",
+                                  "name": "MAP"
+                                },
+                                "named": false,
+                                "value": "map"
                               }
                             ]
                           },
@@ -6857,8 +7812,13 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "INERTIAL"
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "INERTIAL"
+                    },
+                    "named": false,
+                    "value": "inertial"
                   },
                   {
                     "type": "BLANK"
@@ -6872,8 +7832,13 @@
             ]
           },
           {
-            "type": "SYMBOL",
-            "name": "OPEN"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "OPEN"
+            },
+            "named": false,
+            "value": "open"
           }
         ]
       }
@@ -6996,8 +7961,13 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "RETURN"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "RETURN"
+                  },
+                  "named": false,
+                  "value": "return"
                 },
                 {
                   "type": "SYMBOL",
@@ -7045,8 +8015,18 @@
           "name": "operator_symbol"
         },
         {
-          "type": "SYMBOL",
-          "name": "ALL"
+          "type": "ALIAS",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ALL"
+            },
+            "named": false,
+            "value": "all"
+          },
+          "named": false,
+          "value": "all"
         }
       ]
     },
@@ -7107,8 +8087,13 @@
           "name": "library_constant_standard"
         },
         {
-          "type": "SYMBOL",
-          "name": "NULL"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "NULL"
+          },
+          "named": false,
+          "value": "null"
         }
       ]
     },
@@ -7180,8 +8165,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "NEW"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "NEW"
+          },
+          "named": false,
+          "value": "new"
         },
         {
           "type": "SYMBOL",
@@ -7273,8 +8263,13 @@
           "name": "_range"
         },
         {
-          "type": "SYMBOL",
-          "name": "OTHERS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "OTHERS"
+          },
+          "named": false,
+          "value": "others"
         },
         {
           "type": "SYMBOL",
@@ -7341,12 +8336,22 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "TO"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "TO"
+          },
+          "named": false,
+          "value": "to"
         },
         {
-          "type": "SYMBOL",
-          "name": "DOWNTO"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "DOWNTO"
+          },
+          "named": false,
+          "value": "downto"
         }
       ]
     },
@@ -7466,16 +8471,26 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IF"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IF"
+          },
+          "named": false,
+          "value": "if"
         },
         {
           "type": "SYMBOL",
           "name": "conditional_analysis_expression"
         },
         {
-          "type": "SYMBOL",
-          "name": "THEN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "THEN"
+          },
+          "named": false,
+          "value": "then"
         }
       ]
     },
@@ -7483,16 +8498,26 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ELSIF"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ELSIF"
+          },
+          "named": false,
+          "value": "elsif"
         },
         {
           "type": "SYMBOL",
           "name": "conditional_analysis_expression"
         },
         {
-          "type": "SYMBOL",
-          "name": "THEN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "THEN"
+          },
+          "named": false,
+          "value": "then"
         }
       ]
     },
@@ -7500,8 +8525,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ELSE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ELSE"
+          },
+          "named": false,
+          "value": "else"
         }
       ]
     },
@@ -7509,15 +8539,25 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "IF"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "IF"
+              },
+              "named": false,
+              "value": "if"
             },
             {
               "type": "BLANK"
@@ -7683,8 +8723,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "FOR"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FOR"
+          },
+          "named": false,
+          "value": "for"
         },
         {
           "type": "SYMBOL",
@@ -7718,8 +8763,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "FOR"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FOR"
+          },
+          "named": false,
+          "value": "for"
         },
         {
           "type": "SYMBOL",
@@ -7779,12 +8829,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
-          "type": "SYMBOL",
-          "name": "FOR"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FOR"
+          },
+          "named": false,
+          "value": "for"
         }
       ]
     },
@@ -7883,8 +8943,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "CONSTANT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "CONSTANT"
+          },
+          "named": false,
+          "value": "constant"
         },
         {
           "type": "SYMBOL",
@@ -7904,8 +8969,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "SIGNAL"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "SIGNAL"
+          },
+          "named": false,
+          "value": "signal"
         },
         {
           "type": "SYMBOL",
@@ -7925,8 +8995,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "VARIABLE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "VARIABLE"
+          },
+          "named": false,
+          "value": "variable"
         },
         {
           "type": "SYMBOL",
@@ -7956,8 +9031,13 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "IS"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "IS"
+                  },
+                  "named": false,
+                  "value": "is"
                 },
                 {
                   "type": "SYMBOL",
@@ -7992,8 +9072,13 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "PROCEDURE"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "PROCEDURE"
+            },
+            "named": false,
+            "value": "procedure"
           },
           {
             "type": "SYMBOL",
@@ -8030,8 +9115,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "PROCEDURE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PROCEDURE"
+          },
+          "named": false,
+          "value": "procedure"
         },
         {
           "type": "SYMBOL",
@@ -8061,12 +9151,22 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "PURE"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "PURE"
+                  },
+                  "named": false,
+                  "value": "pure"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "IMPURE"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "IMPURE"
+                  },
+                  "named": false,
+                  "value": "impure"
                 }
               ]
             },
@@ -8076,8 +9176,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "FUNCTION"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FUNCTION"
+          },
+          "named": false,
+          "value": "function"
         },
         {
           "type": "SYMBOL",
@@ -8108,8 +9213,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "RETURN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "RETURN"
+          },
+          "named": false,
+          "value": "return"
         },
         {
           "type": "CHOICE",
@@ -8122,8 +9232,13 @@
                   "name": "_identifier"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "OF"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "OF"
+                  },
+                  "named": false,
+                  "value": "of"
                 }
               ]
             },
@@ -8148,12 +9263,22 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "PURE"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "PURE"
+                  },
+                  "named": false,
+                  "value": "pure"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "IMPURE"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "IMPURE"
+                  },
+                  "named": false,
+                  "value": "impure"
                 }
               ]
             },
@@ -8163,8 +9288,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "FUNCTION"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FUNCTION"
+          },
+          "named": false,
+          "value": "function"
         },
         {
           "type": "SYMBOL",
@@ -8183,8 +9313,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "RETURN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "RETURN"
+          },
+          "named": false,
+          "value": "return"
         },
         {
           "type": "SYMBOL",
@@ -8213,20 +9348,35 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "GENERIC"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "GENERIC"
+          },
+          "named": false,
+          "value": "generic"
         },
         {
-          "type": "SYMBOL",
-          "name": "MAP"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "MAP"
+          },
+          "named": false,
+          "value": "map"
         },
         {
           "type": "STRING",
           "value": "("
         },
         {
-          "type": "SYMBOL",
-          "name": "box"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "box"
+          },
+          "named": false,
+          "value": "<>"
         },
         {
           "type": "STRING",
@@ -8238,20 +9388,35 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "GENERIC"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "GENERIC"
+          },
+          "named": false,
+          "value": "generic"
         },
         {
-          "type": "SYMBOL",
-          "name": "MAP"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "MAP"
+          },
+          "named": false,
+          "value": "map"
         },
         {
           "type": "STRING",
           "value": "("
         },
         {
-          "type": "SYMBOL",
-          "name": "DEFAULT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "DEFAULT"
+          },
+          "named": false,
+          "value": "default"
         },
         {
           "type": "STRING",
@@ -8263,12 +9428,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "GENERIC"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "GENERIC"
+          },
+          "named": false,
+          "value": "generic"
         },
         {
-          "type": "SYMBOL",
-          "name": "MAP"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "MAP"
+          },
+          "named": false,
+          "value": "map"
         },
         {
           "type": "SYMBOL",
@@ -8280,12 +9455,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "PORT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PORT"
+          },
+          "named": false,
+          "value": "port"
         },
         {
-          "type": "SYMBOL",
-          "name": "MAP"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "MAP"
+          },
+          "named": false,
+          "value": "map"
         },
         {
           "type": "SYMBOL",
@@ -8334,8 +9519,13 @@
           "name": "name"
         },
         {
-          "type": "SYMBOL",
-          "name": "box"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "box"
+          },
+          "named": false,
+          "value": "<>"
         }
       ]
     },
@@ -8413,8 +9603,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "BUS"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "BUS"
+              },
+              "named": false,
+              "value": "bus"
             },
             {
               "type": "BLANK"
@@ -8452,8 +9647,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "VIEW"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "VIEW"
+          },
+          "named": false,
+          "value": "view"
         },
         {
           "type": "SYMBOL",
@@ -8466,8 +9666,13 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "OF"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "OF"
+                  },
+                  "named": false,
+                  "value": "of"
                 },
                 {
                   "type": "SYMBOL",
@@ -8486,8 +9691,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "VIEW"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "VIEW"
+          },
+          "named": false,
+          "value": "view"
         },
         {
           "type": "STRING",
@@ -8508,8 +9718,13 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "OF"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "OF"
+                  },
+                  "named": false,
+                  "value": "of"
                 },
                 {
                   "type": "SYMBOL",
@@ -8600,8 +9815,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "VIEW"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "VIEW"
+          },
+          "named": false,
+          "value": "view"
         },
         {
           "type": "SYMBOL",
@@ -8613,8 +9833,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "VIEW"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "VIEW"
+          },
+          "named": false,
+          "value": "view"
         },
         {
           "type": "STRING",
@@ -8634,24 +9859,49 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IN"
+          },
+          "named": false,
+          "value": "in"
         },
         {
-          "type": "SYMBOL",
-          "name": "OUT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "OUT"
+          },
+          "named": false,
+          "value": "out"
         },
         {
-          "type": "SYMBOL",
-          "name": "INOUT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "INOUT"
+          },
+          "named": false,
+          "value": "inout"
         },
         {
-          "type": "SYMBOL",
-          "name": "BUFFER"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "BUFFER"
+          },
+          "named": false,
+          "value": "buffer"
         },
         {
-          "type": "SYMBOL",
-          "name": "LINKAGE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "LINKAGE"
+          },
+          "named": false,
+          "value": "linkage"
         }
       ]
     },
@@ -8659,8 +9909,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "RANGE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "RANGE"
+          },
+          "named": false,
+          "value": "range"
         },
         {
           "type": "SYMBOL",
@@ -8729,8 +9984,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "box"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "box"
+              },
+              "named": false,
+              "value": "<>"
             },
             {
               "type": "BLANK"
@@ -8785,12 +10045,27 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "OTHERS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "OTHERS"
+          },
+          "named": false,
+          "value": "others"
         },
         {
-          "type": "SYMBOL",
-          "name": "ALL"
+          "type": "ALIAS",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ALL"
+            },
+            "named": false,
+            "value": "all"
+          },
+          "named": false,
+          "value": "all"
         }
       ]
     },
@@ -8815,84 +10090,189 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ENTITY"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ENTITY"
+          },
+          "named": false,
+          "value": "entity"
         },
         {
-          "type": "SYMBOL",
-          "name": "ARCHITECTURE"
+          "type": "ALIAS",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ARCHITECTURE"
+            },
+            "named": false,
+            "value": "architecture"
+          },
+          "named": false,
+          "value": "architecture"
         },
         {
-          "type": "SYMBOL",
-          "name": "CONFIGURATION"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "CONFIGURATION"
+          },
+          "named": false,
+          "value": "configuration"
         },
         {
-          "type": "SYMBOL",
-          "name": "PROCEDURE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PROCEDURE"
+          },
+          "named": false,
+          "value": "procedure"
         },
         {
-          "type": "SYMBOL",
-          "name": "FUNCTION"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FUNCTION"
+          },
+          "named": false,
+          "value": "function"
         },
         {
-          "type": "SYMBOL",
-          "name": "PACKAGE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PACKAGE"
+          },
+          "named": false,
+          "value": "package"
         },
         {
-          "type": "SYMBOL",
-          "name": "TYPE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "TYPE"
+          },
+          "named": false,
+          "value": "type"
         },
         {
-          "type": "SYMBOL",
-          "name": "SUBTYPE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "SUBTYPE"
+          },
+          "named": false,
+          "value": "subtype"
         },
         {
-          "type": "SYMBOL",
-          "name": "CONSTANT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "CONSTANT"
+          },
+          "named": false,
+          "value": "constant"
         },
         {
-          "type": "SYMBOL",
-          "name": "SIGNAL"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "SIGNAL"
+          },
+          "named": false,
+          "value": "signal"
         },
         {
-          "type": "SYMBOL",
-          "name": "VARIABLE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "VARIABLE"
+          },
+          "named": false,
+          "value": "variable"
         },
         {
-          "type": "SYMBOL",
-          "name": "COMPONENT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "COMPONENT"
+          },
+          "named": false,
+          "value": "component"
         },
         {
-          "type": "SYMBOL",
-          "name": "LABEL"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "LABEL"
+          },
+          "named": false,
+          "value": "label"
         },
         {
-          "type": "SYMBOL",
-          "name": "LITERAL"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "LITERAL"
+          },
+          "named": false,
+          "value": "literal"
         },
         {
-          "type": "SYMBOL",
-          "name": "UNITS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "UNITS"
+          },
+          "named": false,
+          "value": "units"
         },
         {
-          "type": "SYMBOL",
-          "name": "GROUP"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "GROUP"
+          },
+          "named": false,
+          "value": "group"
         },
         {
-          "type": "SYMBOL",
-          "name": "FILE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FILE"
+          },
+          "named": false,
+          "value": "file"
         },
         {
-          "type": "SYMBOL",
-          "name": "PROPERTY"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PROPERTY"
+          },
+          "named": false,
+          "value": "property"
         },
         {
-          "type": "SYMBOL",
-          "name": "SEQUENCE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "SEQUENCE"
+          },
+          "named": false,
+          "value": "sequence"
         },
         {
-          "type": "SYMBOL",
-          "name": "VIEW"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "VIEW"
+          },
+          "named": false,
+          "value": "view"
         }
       ]
     },
@@ -8925,12 +10305,27 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "OTHERS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "OTHERS"
+          },
+          "named": false,
+          "value": "others"
         },
         {
-          "type": "SYMBOL",
-          "name": "ALL"
+          "type": "ALIAS",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ALL"
+            },
+            "named": false,
+            "value": "all"
+          },
+          "named": false,
+          "value": "all"
         }
       ]
     },
@@ -8999,8 +10394,13 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "OPEN"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "OPEN"
+                  },
+                  "named": false,
+                  "value": "open"
                 },
                 {
                   "type": "SYMBOL",
@@ -9014,8 +10414,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "IS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IS"
+          },
+          "named": false,
+          "value": "is"
         },
         {
           "type": "SYMBOL",
@@ -9061,8 +10466,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "GENERIC"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "GENERIC"
+          },
+          "named": false,
+          "value": "generic"
         },
         {
           "type": "STRING",
@@ -9086,8 +10496,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "GENERIC"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "GENERIC"
+          },
+          "named": false,
+          "value": "generic"
         },
         {
           "type": "STRING",
@@ -9135,8 +10550,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "PARAMETER"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "PARAMETER"
+              },
+              "named": false,
+              "value": "parameter"
             },
             {
               "type": "BLANK"
@@ -9206,8 +10626,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "NEW"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "NEW"
+          },
+          "named": false,
+          "value": "new"
         },
         {
           "type": "SYMBOL",
@@ -9231,8 +10656,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "PROTECTED"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PROTECTED"
+          },
+          "named": false,
+          "value": "protected"
         },
         {
           "type": "CHOICE",
@@ -9263,12 +10693,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
-          "type": "SYMBOL",
-          "name": "PROTECTED"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PROTECTED"
+          },
+          "named": false,
+          "value": "protected"
         },
         {
           "type": "CHOICE",
@@ -9318,12 +10758,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "PROTECTED"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PROTECTED"
+          },
+          "named": false,
+          "value": "protected"
         },
         {
-          "type": "SYMBOL",
-          "name": "BODY"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "BODY"
+          },
+          "named": false,
+          "value": "body"
         },
         {
           "type": "REPEAT",
@@ -9342,16 +10792,31 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
-          "type": "SYMBOL",
-          "name": "PROTECTED"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "PROTECTED"
+          },
+          "named": false,
+          "value": "protected"
         },
         {
-          "type": "SYMBOL",
-          "name": "BODY"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "BODY"
+          },
+          "named": false,
+          "value": "body"
         },
         {
           "type": "CHOICE",
@@ -9371,8 +10836,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "WHILE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "WHILE"
+          },
+          "named": false,
+          "value": "while"
         },
         {
           "type": "SYMBOL",
@@ -9384,8 +10854,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "FOR"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FOR"
+          },
+          "named": false,
+          "value": "for"
         },
         {
           "type": "SYMBOL",
@@ -9401,8 +10876,13 @@
           "name": "_identifier"
         },
         {
-          "type": "SYMBOL",
-          "name": "IN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IN"
+          },
+          "named": false,
+          "value": "in"
         },
         {
           "type": "SYMBOL",
@@ -9492,8 +10972,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "UNAFFECTED"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "UNAFFECTED"
+          },
+          "named": false,
+          "value": "unaffected"
         }
       ]
     },
@@ -9511,8 +10996,18 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "AFTER"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "AFTER"
+                    },
+                    "named": false,
+                    "value": "after"
+                  },
+                  "named": false,
+                  "value": "after"
                 },
                 {
                   "type": "SYMBOL",
@@ -9531,12 +11026,22 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "IN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "IN"
+          },
+          "named": false,
+          "value": "in"
         },
         {
-          "type": "SYMBOL",
-          "name": "OUT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "OUT"
+          },
+          "named": false,
+          "value": "out"
         }
       ]
     },
@@ -9577,8 +11082,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "WHEN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "WHEN"
+          },
+          "named": false,
+          "value": "when"
         },
         {
           "type": "SYMBOL",
@@ -9631,8 +11141,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ELSE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ELSE"
+          },
+          "named": false,
+          "value": "else"
         },
         {
           "type": "SYMBOL",
@@ -9644,8 +11159,13 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "TRANSPORT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "TRANSPORT"
+          },
+          "named": false,
+          "value": "transport"
         },
         {
           "type": "SEQ",
@@ -9657,8 +11177,13 @@
                   "type": "SEQ",
                   "members": [
                     {
-                      "type": "SYMBOL",
-                      "name": "REJECT"
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "REJECT"
+                      },
+                      "named": false,
+                      "value": "reject"
                     },
                     {
                       "type": "SYMBOL",
@@ -9672,8 +11197,13 @@
               ]
             },
             {
-              "type": "SYMBOL",
-              "name": "INERTIAL"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "INERTIAL"
+              },
+              "named": false,
+              "value": "inertial"
             }
           ]
         }
@@ -9771,8 +11301,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ELSE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ELSE"
+          },
+          "named": false,
+          "value": "else"
         },
         {
           "type": "SYMBOL",
@@ -9788,8 +11323,13 @@
           "name": "_expression"
         },
         {
-          "type": "SYMBOL",
-          "name": "UNAFFECTED"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "UNAFFECTED"
+          },
+          "named": false,
+          "value": "unaffected"
         }
       ]
     },
@@ -9810,8 +11350,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ON"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ON"
+          },
+          "named": false,
+          "value": "on"
         },
         {
           "type": "SYMBOL",
@@ -9848,8 +11393,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "UNTIL"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "UNTIL"
+          },
+          "named": false,
+          "value": "until"
         },
         {
           "type": "SYMBOL",
@@ -9861,8 +11411,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "FOR"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "FOR"
+          },
+          "named": false,
+          "value": "for"
         },
         {
           "type": "SYMBOL",
@@ -9878,8 +11433,13 @@
           "name": "range_constraint"
         },
         {
-          "type": "SYMBOL",
-          "name": "UNITS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "UNITS"
+          },
+          "named": false,
+          "value": "units"
         },
         {
           "type": "SYMBOL",
@@ -9962,12 +11522,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
-          "type": "SYMBOL",
-          "name": "UNITS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "UNITS"
+          },
+          "named": false,
+          "value": "units"
         },
         {
           "type": "CHOICE",
@@ -10033,8 +11603,13 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "RECORD"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "RECORD"
+          },
+          "named": false,
+          "value": "record"
         },
         {
           "type": "REPEAT",
@@ -10053,12 +11628,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "END"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "END"
+          },
+          "named": false,
+          "value": "end"
         },
         {
-          "type": "SYMBOL",
-          "name": "RECORD"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "RECORD"
+          },
+          "named": false,
+          "value": "record"
         },
         {
           "type": "CHOICE",
@@ -10099,8 +11684,18 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ALL"
+          "type": "ALIAS",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ALL"
+            },
+            "named": false,
+            "value": "all"
+          },
+          "named": false,
+          "value": "all"
         },
         {
           "type": "SYMBOL",
@@ -10118,8 +11713,13 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "FOR"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "FOR"
+                },
+                "named": false,
+                "value": "for"
               },
               {
                 "type": "SYMBOL",
@@ -10156,8 +11756,13 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "FOR"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "FOR"
+                },
+                "named": false,
+                "value": "for"
               },
               {
                 "type": "SYMBOL",
@@ -10208,12 +11813,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "USE"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "USE"
+          },
+          "named": false,
+          "value": "use"
         },
         {
-          "type": "SYMBOL",
-          "name": "VUNIT"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "VUNIT"
+          },
+          "named": false,
+          "value": "vunit"
         },
         {
           "type": "SYMBOL",
@@ -10292,12 +11907,27 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "OTHERS"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "OTHERS"
+          },
+          "named": false,
+          "value": "others"
         },
         {
-          "type": "SYMBOL",
-          "name": "ALL"
+          "type": "ALIAS",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ALL"
+            },
+            "named": false,
+            "value": "all"
+          },
+          "named": false,
+          "value": "all"
         }
       ]
     },
@@ -10311,8 +11941,13 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "USE"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "USE"
+                  },
+                  "named": false,
+                  "value": "use"
                 },
                 {
                   "type": "SYMBOL",
@@ -10362,8 +11997,13 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "ENTITY"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "ENTITY"
+              },
+              "named": false,
+              "value": "entity"
             },
             {
               "type": "SYMBOL",
@@ -10400,8 +12040,13 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "CONFIGURATION"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "CONFIGURATION"
+              },
+              "named": false,
+              "value": "configuration"
             },
             {
               "type": "SYMBOL",
@@ -10410,8 +12055,13 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "OPEN"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "OPEN"
+          },
+          "named": false,
+          "value": "open"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -133,7 +133,40 @@
   {
     "type": "architecture_definition",
     "named": true,
-    "fields": {},
+    "fields": {
+      "architecture": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      },
+      "entity": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
@@ -148,26 +181,6 @@
         },
         {
           "type": "end_architecture",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        },
-        {
-          "type": "name",
           "named": true
         }
       ]
@@ -273,33 +286,6 @@
     }
   },
   {
-    "type": "architecture_identifier",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "array_index_incomplete_type_list",
     "named": true,
     "fields": {},
@@ -325,15 +311,22 @@
   {
     "type": "array_mode_view_indication",
     "named": true,
-    "fields": {},
+    "fields": {
+      "view": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "name",
-          "named": true
-        },
         {
           "type": "subtype_indication",
           "named": true
@@ -506,55 +499,62 @@
   {
     "type": "attribute",
     "named": true,
-    "fields": {},
+    "fields": {
+      "attribute": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "attribute_function",
+            "named": true
+          },
+          {
+            "type": "attribute_identifier",
+            "named": true
+          },
+          {
+            "type": "attribute_impure_function",
+            "named": true
+          },
+          {
+            "type": "attribute_mode_view",
+            "named": true
+          },
+          {
+            "type": "attribute_pure_function",
+            "named": true
+          },
+          {
+            "type": "attribute_range",
+            "named": true
+          },
+          {
+            "type": "attribute_signal",
+            "named": true
+          },
+          {
+            "type": "attribute_subtype",
+            "named": true
+          },
+          {
+            "type": "attribute_type",
+            "named": true
+          },
+          {
+            "type": "attribute_value",
+            "named": true
+          },
+          {
+            "type": "library_attribute",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "attribute_function",
-          "named": true
-        },
-        {
-          "type": "attribute_identifier",
-          "named": true
-        },
-        {
-          "type": "attribute_impure_function",
-          "named": true
-        },
-        {
-          "type": "attribute_mode_view",
-          "named": true
-        },
-        {
-          "type": "attribute_pure_function",
-          "named": true
-        },
-        {
-          "type": "attribute_range",
-          "named": true
-        },
-        {
-          "type": "attribute_signal",
-          "named": true
-        },
-        {
-          "type": "attribute_subtype",
-          "named": true
-        },
-        {
-          "type": "attribute_type",
-          "named": true
-        },
-        {
-          "type": "attribute_value",
-          "named": true
-        },
-        {
-          "type": "library_attribute",
-          "named": true
-        },
         {
           "type": "parenthesis_expression",
           "named": true
@@ -565,92 +565,106 @@
   {
     "type": "attribute_declaration",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        },
-        {
-          "type": "name",
-          "named": true
-        }
-      ]
+    "fields": {
+      "attribute": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
     "type": "attribute_specification",
     "named": true,
-    "fields": {},
+    "fields": {
+      "attribute": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "attribute_function",
+            "named": true
+          },
+          {
+            "type": "attribute_identifier",
+            "named": true
+          },
+          {
+            "type": "attribute_impure_function",
+            "named": true
+          },
+          {
+            "type": "attribute_mode_view",
+            "named": true
+          },
+          {
+            "type": "attribute_pure_function",
+            "named": true
+          },
+          {
+            "type": "attribute_range",
+            "named": true
+          },
+          {
+            "type": "attribute_signal",
+            "named": true
+          },
+          {
+            "type": "attribute_subtype",
+            "named": true
+          },
+          {
+            "type": "attribute_type",
+            "named": true
+          },
+          {
+            "type": "attribute_value",
+            "named": true
+          },
+          {
+            "type": "library_attribute",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "attribute_function",
-          "named": true
-        },
-        {
-          "type": "attribute_identifier",
-          "named": true
-        },
-        {
-          "type": "attribute_impure_function",
-          "named": true
-        },
-        {
-          "type": "attribute_mode_view",
-          "named": true
-        },
-        {
-          "type": "attribute_pure_function",
-          "named": true
-        },
-        {
-          "type": "attribute_range",
-          "named": true
-        },
-        {
-          "type": "attribute_signal",
-          "named": true
-        },
-        {
-          "type": "attribute_subtype",
-          "named": true
-        },
-        {
-          "type": "attribute_type",
-          "named": true
-        },
-        {
-          "type": "attribute_value",
-          "named": true
-        },
         {
           "type": "conditional_expression",
           "named": true
         },
         {
           "type": "entity_specification",
-          "named": true
-        },
-        {
-          "type": "library_attribute",
           "named": true
         }
       ]
@@ -1471,7 +1485,30 @@
   {
     "type": "component_declaration",
     "named": true,
-    "fields": {},
+    "fields": {
+      "component": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
@@ -1482,22 +1519,6 @@
         },
         {
           "type": "end_component",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
           "named": true
         }
       ]
@@ -2018,7 +2039,40 @@
   {
     "type": "configuration_declaration",
     "named": true,
-    "fields": {},
+    "fields": {
+      "configuration": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      },
+      "entity": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
@@ -2033,26 +2087,6 @@
         },
         {
           "type": "end_configuration",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        },
-        {
-          "type": "name",
           "named": true
         }
       ]
@@ -2464,16 +2498,17 @@
   {
     "type": "element_array_mode_view_indication",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "name",
-          "named": true
-        }
-      ]
+    "fields": {
+      "view": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -2560,16 +2595,17 @@
   {
     "type": "element_record_mode_view_indication",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "name",
-          "named": true
-        }
-      ]
+    "fields": {
+      "view": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -2780,28 +2816,29 @@
   {
     "type": "end_architecture",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        }
-      ]
+    "fields": {
+      "architecture": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -2837,28 +2874,29 @@
   {
     "type": "end_component",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        }
-      ]
+    "fields": {
+      "component": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -2869,28 +2907,29 @@
   {
     "type": "end_configuration",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        }
-      ]
+    "fields": {
+      "configuration": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -2923,28 +2962,29 @@
   {
     "type": "end_entity",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        }
-      ]
+    "fields": {
+      "entity": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -3000,55 +3040,57 @@
   {
     "type": "end_package",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        }
-      ]
+    "fields": {
+      "package": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
     "type": "end_package_body",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        }
-      ]
+    "fields": {
+      "package": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -3123,60 +3165,84 @@
   {
     "type": "end_view",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        }
-      ]
+    "fields": {
+      "view": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
     "type": "entity_aspect",
     "named": true,
-    "fields": {},
+    "fields": {
+      "architecture": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      },
+      "configuration": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      },
+      "entity": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
         {
           "type": "OPEN",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        },
-        {
-          "type": "name",
           "named": true
         }
       ]
@@ -3228,7 +3294,30 @@
   {
     "type": "entity_declaration",
     "named": true,
-    "fields": {},
+    "fields": {
+      "entity": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
@@ -3243,22 +3332,6 @@
         },
         {
           "type": "entity_head",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
           "named": true
         }
       ]
@@ -3647,13 +3720,24 @@
   {
     "type": "file_incomplete_type_definition",
     "named": true,
-    "fields": {},
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
-          "type": "incomplete_type_mark",
+          "type": "unspecified_type_indication",
           "named": true
         }
       ]
@@ -3732,16 +3816,17 @@
   {
     "type": "file_type_definition",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "name",
-          "named": true
-        }
-      ]
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -3818,10 +3903,47 @@
   {
     "type": "function_specification",
     "named": true,
-    "fields": {},
+    "fields": {
+      "function": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          },
+          {
+            "type": "operator_symbol",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "identifier",
@@ -3837,14 +3959,6 @@
         },
         {
           "type": "library_type",
-          "named": true
-        },
-        {
-          "type": "name",
-          "named": true
-        },
-        {
-          "type": "operator_symbol",
           "named": true
         },
         {
@@ -4274,15 +4388,22 @@
   {
     "type": "guarded_signal_specification",
     "named": true,
-    "fields": {},
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "name",
-          "named": true
-        },
         {
           "type": "signal_list",
           "named": true
@@ -4560,25 +4681,6 @@
     }
   },
   {
-    "type": "incomplete_type_mark",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "name",
-          "named": true
-        },
-        {
-          "type": "unspecified_type_indication",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "index_constraint",
     "named": true,
     "fields": {},
@@ -4616,16 +4718,17 @@
   {
     "type": "index_subtype_definition",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "name",
-          "named": true
-        }
-      ]
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -4650,24 +4753,69 @@
   {
     "type": "instantiated_unit",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "architecture_identifier",
-          "named": true
-        },
-        {
-          "type": "library_namespace",
-          "named": true
-        },
-        {
-          "type": "name",
-          "named": true
-        }
-      ]
+    "fields": {
+      "architecture": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      },
+      "component": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      },
+      "configuration": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      },
+      "entity": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      },
+      "library": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "library_namespace",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -4774,35 +4922,48 @@
   {
     "type": "interface_function_specification",
     "named": true,
-    "fields": {},
+    "fields": {
+      "function": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          },
+          {
+            "type": "operator_symbol",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        },
-        {
-          "type": "name",
-          "named": true
-        },
-        {
-          "type": "operator_symbol",
-          "named": true
-        },
         {
           "type": "parameter_list_specification",
           "named": true
@@ -4856,7 +5017,30 @@
   {
     "type": "interface_package_declaration",
     "named": true,
-    "fields": {},
+    "fields": {
+      "package": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
@@ -4874,22 +5058,6 @@
           "named": true
         },
         {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        },
-        {
           "type": "name",
           "named": true
         }
@@ -4899,31 +5067,38 @@
   {
     "type": "interface_procedure_specification",
     "named": true,
-    "fields": {},
+    "fields": {
+      "procedure": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          },
+          {
+            "type": "operator_symbol",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        },
-        {
-          "type": "operator_symbol",
-          "named": true
-        },
         {
           "type": "parameter_list_specification",
           "named": true
@@ -4984,10 +5159,33 @@
   {
     "type": "interface_type_declaration",
     "named": true,
-    "fields": {},
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
         {
           "type": "access_incomplete_type_definition",
@@ -5010,23 +5208,7 @@
           "named": true
         },
         {
-          "type": "identifier",
-          "named": true
-        },
-        {
           "type": "integer_incomplete_type_definition",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
           "named": true
         },
         {
@@ -5154,32 +5336,33 @@
   {
     "type": "logical_name_list",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_namespace",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        }
-      ]
+    "fields": {
+      "library": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_namespace",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -5332,29 +5515,36 @@
   {
     "type": "mode_view_declaration",
     "named": true,
-    "fields": {},
+    "fields": {
+      "view": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
       "types": [
         {
           "type": "end_view",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
           "named": true
         },
         {
@@ -5409,6 +5599,10 @@
       "required": true,
       "types": [
         {
+          "type": "attribute",
+          "named": true
+        },
+        {
           "type": "character_literal",
           "named": true
         },
@@ -5422,6 +5616,10 @@
         },
         {
           "type": "external_variable_name",
+          "named": true
+        },
+        {
+          "type": "function_call",
           "named": true
         },
         {
@@ -5445,30 +5643,7 @@
           "named": true
         },
         {
-          "type": "name_selector",
-          "named": true
-        },
-        {
           "type": "operator_symbol",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "name_selector",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "attribute",
-          "named": true
-        },
-        {
-          "type": "function_call",
           "named": true
         },
         {
@@ -5527,29 +5702,36 @@
   {
     "type": "package_declaration",
     "named": true,
-    "fields": {},
+    "fields": {
+      "package": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
       "types": [
         {
           "type": "end_package",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
           "named": true
         },
         {
@@ -5653,29 +5835,36 @@
   {
     "type": "package_definition",
     "named": true,
-    "fields": {},
+    "fields": {
+      "package": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
       "types": [
         {
           "type": "end_package_body",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
           "named": true
         },
         {
@@ -5786,29 +5975,36 @@
   {
     "type": "package_instantiation_declaration",
     "named": true,
-    "fields": {},
+    "fields": {
+      "package": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
       "types": [
         {
           "type": "generic_map_aspect",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
           "named": true
         },
         {
@@ -6150,31 +6346,38 @@
   {
     "type": "procedure_specification",
     "named": true,
-    "fields": {},
+    "fields": {
+      "procedure": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          },
+          {
+            "type": "operator_symbol",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        },
-        {
-          "type": "operator_symbol",
-          "named": true
-        },
         {
           "type": "parameter_list_specification",
           "named": true
@@ -6629,15 +6832,22 @@
   {
     "type": "record_mode_view_indication",
     "named": true,
-    "fields": {},
+    "fields": {
+      "view": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "name",
-          "named": true
-        },
         {
           "type": "subtype_indication",
           "named": true
@@ -6978,10 +7188,37 @@
   {
     "type": "selected_name",
     "named": true,
-    "fields": {},
+    "fields": {
+      "library": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_namespace",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "ALL",
@@ -6997,10 +7234,6 @@
         },
         {
           "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_namespace",
           "named": true
         },
         {
@@ -7522,22 +7755,38 @@
   {
     "type": "signature",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "name",
-          "named": true
-        }
-      ]
+    "fields": {
+      "type": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
     "type": "simple_expression",
     "named": true,
-    "fields": {},
+    "fields": {
+      "unit": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "library_constant_unit",
+            "named": true
+          },
+          {
+            "type": "unit",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": false,
@@ -7595,10 +7844,6 @@
           "named": true
         },
         {
-          "type": "library_constant_unit",
-          "named": true
-        },
-        {
           "type": "logical_expression",
           "named": true
         },
@@ -7640,10 +7885,6 @@
         },
         {
           "type": "unary_operator",
-          "named": true
-        },
-        {
-          "type": "unit",
           "named": true
         }
       ]
@@ -7876,32 +8117,33 @@
   {
     "type": "subprogram_end",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        },
-        {
-          "type": "operator_symbol",
-          "named": true
-        }
-      ]
+    "fields": {
+      "function": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          },
+          {
+            "type": "operator_symbol",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -8005,7 +8247,60 @@
   {
     "type": "subprogram_instantiation_declaration",
     "named": true,
-    "fields": {},
+    "fields": {
+      "function": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          },
+          {
+            "type": "operator_symbol",
+            "named": true
+          }
+        ]
+      },
+      "procedure": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          },
+          {
+            "type": "operator_symbol",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
@@ -8015,27 +8310,7 @@
           "named": true
         },
         {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        },
-        {
           "type": "name",
-          "named": true
-        },
-        {
-          "type": "operator_symbol",
           "named": true
         },
         {
@@ -8048,27 +8323,34 @@
   {
     "type": "subtype_declaration",
     "named": true,
-    "fields": {},
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
-          "named": true
-        },
         {
           "type": "subtype_indication",
           "named": true
@@ -8079,15 +8361,22 @@
   {
     "type": "subtype_indication",
     "named": true,
-    "fields": {},
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "name",
-          "named": true
-        },
         {
           "type": "range_constraint",
           "named": true
@@ -8133,10 +8422,33 @@
   {
     "type": "type_declaration",
     "named": true,
-    "fields": {},
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "library_constant",
+            "named": true
+          },
+          {
+            "type": "library_function",
+            "named": true
+          },
+          {
+            "type": "library_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
         {
           "type": "access_type_definition",
@@ -8152,22 +8464,6 @@
         },
         {
           "type": "file_type_definition",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "library_constant",
-          "named": true
-        },
-        {
-          "type": "library_function",
-          "named": true
-        },
-        {
-          "type": "library_type",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -19,13 +19,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "ACCESS",
-          "named": true
-        },
         {
           "type": "subtype_indication",
           "named": true
@@ -45,10 +41,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "ACCESS",
-          "named": true
-        },
         {
           "type": "generic_map_aspect",
           "named": true
@@ -89,14 +81,6 @@
       "required": true,
       "types": [
         {
-          "type": "ALIAS",
-          "named": true
-        },
-        {
-          "type": "IS",
-          "named": true
-        },
-        {
           "type": "character_literal",
           "named": true
         },
@@ -136,13 +120,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "NEW",
-          "named": true
-        },
         {
           "type": "name",
           "named": true
@@ -158,14 +138,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "ARCHITECTURE",
-          "named": true
-        },
-        {
-          "type": "OF",
-          "named": true
-        },
         {
           "type": "architecture_head",
           "named": true
@@ -207,12 +179,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
         {
           "type": "alias_declaration",
           "named": true
@@ -363,14 +331,6 @@
       "required": true,
       "types": [
         {
-          "type": "OF",
-          "named": true
-        },
-        {
-          "type": "VIEW",
-          "named": true
-        },
-        {
           "type": "name",
           "named": true
         },
@@ -389,14 +349,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "ARRAY",
-          "named": true
-        },
-        {
-          "type": "OF",
-          "named": true
-        },
         {
           "type": "array_index_incomplete_type_list",
           "named": true
@@ -424,10 +376,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "ASSERT",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -484,16 +432,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "INERTIAL",
-          "named": true
-        },
-        {
-          "type": "OPEN",
-          "named": true
-        },
         {
           "type": "conditional_expression",
           "named": true
@@ -627,10 +567,6 @@
       "required": true,
       "types": [
         {
-          "type": "ATTRIBUTE",
-          "named": true
-        },
-        {
           "type": "identifier",
           "named": true
         },
@@ -661,18 +597,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "ATTRIBUTE",
-          "named": true
-        },
-        {
-          "type": "IS",
-          "named": true
-        },
-        {
-          "type": "OF",
-          "named": true
-        },
         {
           "type": "attribute_function",
           "named": true
@@ -760,10 +684,6 @@
       "required": false,
       "types": [
         {
-          "type": "USE",
-          "named": true
-        },
-        {
           "type": "entity_aspect",
           "named": true
         },
@@ -825,10 +745,6 @@
       "required": true,
       "types": [
         {
-          "type": "FOR",
-          "named": true
-        },
-        {
           "type": "block_configuration",
           "named": true
         },
@@ -857,12 +773,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
         {
           "type": "alias_declaration",
           "named": true
@@ -979,10 +891,6 @@
       "required": true,
       "types": [
         {
-          "type": "BLOCK",
-          "named": true
-        },
-        {
           "type": "block_head",
           "named": true
         },
@@ -1014,10 +922,6 @@
       "required": true,
       "types": [
         {
-          "type": "IS",
-          "named": true
-        },
-        {
           "type": "case_statement_alternative",
           "named": true
         }
@@ -1029,13 +933,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "CASE",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -1067,14 +967,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "OTHERS",
-          "named": true
-        },
-        {
-          "type": "WHEN",
-          "named": true
-        },
         {
           "type": "case_generate_body",
           "named": true
@@ -1122,10 +1014,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "GENERATE",
-          "named": true
-        },
         {
           "type": "case_generate_alternative",
           "named": true
@@ -1323,10 +1211,6 @@
       "required": true,
       "types": [
         {
-          "type": "CASE",
-          "named": true
-        },
-        {
           "type": "case_generate_block",
           "named": true
         },
@@ -1489,12 +1373,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "OTHERS",
-          "named": true
-        },
         {
           "type": "choices",
           "named": true
@@ -1532,12 +1412,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
         {
           "type": "generic_clause",
           "named": true
@@ -1557,10 +1433,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "FOR",
-          "named": true
-        },
         {
           "type": "binding_indication",
           "named": true
@@ -1592,10 +1464,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "COMPONENT",
-          "named": true
-        },
         {
           "type": "component_body",
           "named": true
@@ -1682,10 +1550,6 @@
       "required": true,
       "types": [
         {
-          "type": "POSTPONED",
-          "named": true
-        },
-        {
           "type": "assertion",
           "named": true
         },
@@ -1702,12 +1566,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "BEGIN",
-          "named": true
-        },
         {
           "type": "block_statement",
           "named": true
@@ -1764,14 +1624,6 @@
       "required": true,
       "types": [
         {
-          "type": "GUARDED",
-          "named": true
-        },
-        {
-          "type": "POSTPONED",
-          "named": true
-        },
-        {
           "type": "aggregate",
           "named": true
         },
@@ -1807,10 +1659,6 @@
       "required": true,
       "types": [
         {
-          "type": "POSTPONED",
-          "named": true
-        },
-        {
           "type": "label_declaration",
           "named": true
         },
@@ -1829,14 +1677,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "GUARDED",
-          "named": true
-        },
-        {
-          "type": "POSTPONED",
-          "named": true
-        },
         {
           "type": "delay_mechanism",
           "named": true
@@ -1873,14 +1713,6 @@
       "required": true,
       "types": [
         {
-          "type": "GUARDED",
-          "named": true
-        },
-        {
-          "type": "POSTPONED",
-          "named": true
-        },
-        {
           "type": "aggregate",
           "named": true
         },
@@ -1912,13 +1744,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "UNTIL",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -2084,12 +1912,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "UNAFFECTED",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -2188,14 +2012,6 @@
       "required": true,
       "types": [
         {
-          "type": "CONFIGURATION",
-          "named": true
-        },
-        {
-          "type": "OF",
-          "named": true
-        },
-        {
           "type": "block_configuration",
           "named": true
         },
@@ -2236,12 +2052,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
         {
           "type": "attribute_specification",
           "named": true
@@ -2270,10 +2082,6 @@
       "required": true,
       "types": [
         {
-          "type": "FOR",
-          "named": true
-        },
-        {
           "type": "binding_indication",
           "named": true
         },
@@ -2301,10 +2109,6 @@
       "required": true,
       "types": [
         {
-          "type": "CONSTANT",
-          "named": true
-        },
-        {
           "type": "identifier_list",
           "named": true
         },
@@ -2327,10 +2131,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "CONTEXT",
-          "named": true
-        },
         {
           "type": "context_declaration_body",
           "named": true
@@ -2364,12 +2164,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
         {
           "type": "context_reference",
           "named": true
@@ -2390,13 +2186,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "CONTEXT",
-          "named": true
-        },
         {
           "type": "selected_name_list",
           "named": true
@@ -2409,21 +2201,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "INERTIAL",
-          "named": true
-        },
-        {
-          "type": "REJECT",
-          "named": true
-        },
-        {
-          "type": "TRANSPORT",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -2638,14 +2418,6 @@
       "required": true,
       "types": [
         {
-          "type": "AFTER",
-          "named": true
-        },
-        {
-          "type": "DISCONNECT",
-          "named": true
-        },
-        {
           "type": "condition_expression",
           "named": true
         },
@@ -2675,30 +2447,16 @@
   {
     "type": "discrete_incomplete_type_definition",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "box",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "element_array_mode_view_indication",
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "VIEW",
-          "named": true
-        },
         {
           "type": "name",
           "named": true
@@ -2714,10 +2472,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "OTHERS",
-          "named": true
-        },
         {
           "type": "choices",
           "named": true
@@ -2792,13 +2546,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "VIEW",
-          "named": true
-        },
         {
           "type": "name",
           "named": true
@@ -2809,30 +2559,16 @@
   {
     "type": "else_conditional_analysis",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "ELSE",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "else_expression",
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "ELSE",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -2861,17 +2597,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "ELSE",
-          "named": true
-        },
-        {
-          "type": "UNAFFECTED",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -2904,10 +2632,6 @@
       "required": true,
       "types": [
         {
-          "type": "ELSE",
-          "named": true
-        },
-        {
           "type": "generate_body",
           "named": true
         },
@@ -2923,13 +2647,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "ELSE",
-          "named": true
-        },
         {
           "type": "if_statement_body",
           "named": true
@@ -2942,13 +2662,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "ELSE",
-          "named": true
-        },
         {
           "type": "waveform",
           "named": true
@@ -2961,17 +2677,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "ELSIF",
-          "named": true
-        },
-        {
-          "type": "THEN",
-          "named": true
-        },
         {
           "type": "conditional_analysis_expression",
           "named": true
@@ -2987,10 +2695,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "ELSIF",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -3031,14 +2735,6 @@
       "required": true,
       "types": [
         {
-          "type": "ELSIF",
-          "named": true
-        },
-        {
-          "type": "THEN",
-          "named": true
-        },
-        {
           "type": "condition_expression",
           "named": true
         },
@@ -3070,17 +2766,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "ARCHITECTURE",
-          "named": true
-        },
-        {
-          "type": "END",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -3105,17 +2793,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "BLOCK",
-          "named": true
-        },
-        {
-          "type": "END",
-          "named": true
-        },
         {
           "type": "label",
           "named": true
@@ -3128,17 +2808,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "CASE",
-          "named": true
-        },
-        {
-          "type": "END",
-          "named": true
-        },
         {
           "type": "label",
           "named": true
@@ -3151,17 +2823,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "COMPONENT",
-          "named": true
-        },
-        {
-          "type": "END",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -3184,38 +2848,16 @@
   {
     "type": "end_conditional_analysis",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "IF",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "end_configuration",
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "CONFIGURATION",
-          "named": true
-        },
-        {
-          "type": "END",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -3240,17 +2882,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "CONTEXT",
-          "named": true
-        },
-        {
-          "type": "END",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -3275,17 +2909,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "ENTITY",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -3308,38 +2934,16 @@
   {
     "type": "end_for",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "FOR",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "end_generate",
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "GENERATE",
-          "named": true
-        },
         {
           "type": "label",
           "named": true
@@ -3352,17 +2956,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "IF",
-          "named": true
-        },
         {
           "type": "label",
           "named": true
@@ -3375,17 +2971,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "LOOP",
-          "named": true
-        },
         {
           "type": "label",
           "named": true
@@ -3398,17 +2986,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "PACKAGE",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -3433,21 +3013,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "BODY",
-          "named": true
-        },
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "PACKAGE",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -3472,21 +3040,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "POSTPONED",
-          "named": true
-        },
-        {
-          "type": "PROCESS",
-          "named": true
-        },
         {
           "type": "label",
           "named": true
@@ -3499,17 +3055,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "RECORD",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -3534,17 +3082,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "UNITS",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -3569,17 +3109,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "VIEW",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -3605,20 +3137,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "CONFIGURATION",
-          "named": true
-        },
-        {
-          "type": "ENTITY",
-          "named": true
-        },
-        {
-          "type": "OPEN",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -3648,12 +3168,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "BEGIN",
-          "named": true
-        },
         {
           "type": "concurrent_assertion_statement",
           "named": true
@@ -3672,97 +3188,7 @@
   {
     "type": "entity_class_entry",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "ARCHITECTURE",
-          "named": true
-        },
-        {
-          "type": "COMPONENT",
-          "named": true
-        },
-        {
-          "type": "CONFIGURATION",
-          "named": true
-        },
-        {
-          "type": "CONSTANT",
-          "named": true
-        },
-        {
-          "type": "ENTITY",
-          "named": true
-        },
-        {
-          "type": "FILE",
-          "named": true
-        },
-        {
-          "type": "FUNCTION",
-          "named": true
-        },
-        {
-          "type": "GROUP",
-          "named": true
-        },
-        {
-          "type": "LABEL",
-          "named": true
-        },
-        {
-          "type": "LITERAL",
-          "named": true
-        },
-        {
-          "type": "PACKAGE",
-          "named": true
-        },
-        {
-          "type": "PROCEDURE",
-          "named": true
-        },
-        {
-          "type": "PROPERTY",
-          "named": true
-        },
-        {
-          "type": "SEQUENCE",
-          "named": true
-        },
-        {
-          "type": "SIGNAL",
-          "named": true
-        },
-        {
-          "type": "SUBTYPE",
-          "named": true
-        },
-        {
-          "type": "TYPE",
-          "named": true
-        },
-        {
-          "type": "UNITS",
-          "named": true
-        },
-        {
-          "type": "VARIABLE",
-          "named": true
-        },
-        {
-          "type": "VIEW",
-          "named": true
-        },
-        {
-          "type": "box",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "entity_class_entry_list",
@@ -3787,10 +3213,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "ENTITY",
-          "named": true
-        },
         {
           "type": "end_entity",
           "named": true
@@ -3867,12 +3289,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
         {
           "type": "alias_declaration",
           "named": true
@@ -3970,16 +3388,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "ALL",
-          "named": true
-        },
-        {
-          "type": "OTHERS",
-          "named": true
-        },
         {
           "type": "entity_designator",
           "named": true
@@ -3992,89 +3402,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "ARCHITECTURE",
-          "named": true
-        },
-        {
-          "type": "COMPONENT",
-          "named": true
-        },
-        {
-          "type": "CONFIGURATION",
-          "named": true
-        },
-        {
-          "type": "CONSTANT",
-          "named": true
-        },
-        {
-          "type": "ENTITY",
-          "named": true
-        },
-        {
-          "type": "FILE",
-          "named": true
-        },
-        {
-          "type": "FUNCTION",
-          "named": true
-        },
-        {
-          "type": "GROUP",
-          "named": true
-        },
-        {
-          "type": "LABEL",
-          "named": true
-        },
-        {
-          "type": "LITERAL",
-          "named": true
-        },
-        {
-          "type": "PACKAGE",
-          "named": true
-        },
-        {
-          "type": "PROCEDURE",
-          "named": true
-        },
-        {
-          "type": "PROPERTY",
-          "named": true
-        },
-        {
-          "type": "SEQUENCE",
-          "named": true
-        },
-        {
-          "type": "SIGNAL",
-          "named": true
-        },
-        {
-          "type": "SUBTYPE",
-          "named": true
-        },
-        {
-          "type": "TYPE",
-          "named": true
-        },
-        {
-          "type": "UNITS",
-          "named": true
-        },
-        {
-          "type": "VARIABLE",
-          "named": true
-        },
-        {
-          "type": "VIEW",
-          "named": true
-        },
         {
           "type": "entity_name_list",
           "named": true
@@ -4153,12 +3483,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "EXIT",
-          "named": true
-        },
         {
           "type": "label",
           "named": true
@@ -4182,10 +3508,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "CONSTANT",
-          "named": true
-        },
         {
           "type": "absolute_pathname",
           "named": true
@@ -4218,10 +3540,6 @@
       "required": true,
       "types": [
         {
-          "type": "SIGNAL",
-          "named": true
-        },
-        {
           "type": "absolute_pathname",
           "named": true
         },
@@ -4252,10 +3570,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "VARIABLE",
-          "named": true
-        },
         {
           "type": "absolute_pathname",
           "named": true
@@ -4288,10 +3602,6 @@
       "required": true,
       "types": [
         {
-          "type": "FILE",
-          "named": true
-        },
-        {
           "type": "file_open_information",
           "named": true
         },
@@ -4311,17 +3621,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "FILE",
-          "named": true
-        },
-        {
-          "type": "OF",
-          "named": true
-        },
         {
           "type": "incomplete_type_mark",
           "named": true
@@ -4369,14 +3671,6 @@
       "required": true,
       "types": [
         {
-          "type": "IS",
-          "named": true
-        },
-        {
-          "type": "OPEN",
-          "named": true
-        },
-        {
           "type": "condition_expression",
           "named": true
         },
@@ -4408,17 +3702,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "FILE",
-          "named": true
-        },
-        {
-          "type": "OF",
-          "named": true
-        },
         {
           "type": "name",
           "named": true
@@ -4429,21 +3715,7 @@
   {
     "type": "floating_incomplete_type_definition",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "RANGE",
-          "named": true
-        },
-        {
-          "type": "box",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "for_generate_statement",
@@ -4477,13 +3749,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "FOR",
-          "named": true
-        },
         {
           "type": "parameter_specification",
           "named": true
@@ -4494,21 +3762,7 @@
   {
     "type": "force_mode",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "IN",
-          "named": true
-        },
-        {
-          "type": "OUT",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "function_call",
@@ -4518,14 +3772,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "MAP",
-          "named": true
-        },
-        {
-          "type": "PARAMETER",
-          "named": true
-        },
         {
           "type": "generic_map_aspect",
           "named": true
@@ -4545,26 +3791,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "FUNCTION",
-          "named": true
-        },
-        {
-          "type": "IMPURE",
-          "named": true
-        },
-        {
-          "type": "OF",
-          "named": true
-        },
-        {
-          "type": "PURE",
-          "named": true
-        },
-        {
-          "type": "RETURN",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -4606,12 +3832,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "BEGIN",
-          "named": true
-        },
         {
           "type": "block_statement",
           "named": true
@@ -4664,13 +3886,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "END",
-          "named": true
-        },
         {
           "type": "label",
           "named": true
@@ -4711,12 +3929,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "GENERATE",
-          "named": true
-        },
         {
           "type": "block_statement",
           "named": true
@@ -4770,12 +3984,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "GENERATE",
-          "named": true
-        },
         {
           "type": "alias_declaration",
           "named": true
@@ -4872,13 +4082,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "GENERIC",
-          "named": true
-        },
         {
           "type": "interface_list",
           "named": true
@@ -4889,42 +4095,16 @@
   {
     "type": "generic_map_any",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "GENERIC",
-          "named": true
-        },
-        {
-          "type": "MAP",
-          "named": true
-        },
-        {
-          "type": "box",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "generic_map_aspect",
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "GENERIC",
-          "named": true
-        },
-        {
-          "type": "MAP",
-          "named": true
-        },
         {
           "type": "association_list",
           "named": true
@@ -4935,25 +4115,7 @@
   {
     "type": "generic_map_default",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "DEFAULT",
-          "named": true
-        },
-        {
-          "type": "GENERIC",
-          "named": true
-        },
-        {
-          "type": "MAP",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "group_constituent_list",
@@ -4978,10 +4140,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "GROUP",
-          "named": true
-        },
         {
           "type": "group_constituent_list",
           "named": true
@@ -5017,14 +4175,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "GROUP",
-          "named": true
-        },
-        {
-          "type": "IS",
-          "named": true
-        },
         {
           "type": "entity_class_entry_list",
           "named": true
@@ -5130,17 +4280,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "IF",
-          "named": true
-        },
-        {
-          "type": "THEN",
-          "named": true
-        },
         {
           "type": "conditional_analysis_expression",
           "named": true
@@ -5156,10 +4298,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "IF",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -5230,14 +4368,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "IF",
-          "named": true
-        },
-        {
-          "type": "THEN",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -5446,17 +4576,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "RANGE",
-          "named": true
-        },
-        {
-          "type": "box",
-          "named": true
-        },
         {
           "type": "name",
           "named": true
@@ -5492,18 +4614,6 @@
       "required": true,
       "types": [
         {
-          "type": "COMPONENT",
-          "named": true
-        },
-        {
-          "type": "CONFIGURATION",
-          "named": true
-        },
-        {
-          "type": "ENTITY",
-          "named": true
-        },
-        {
           "type": "architecture_identifier",
           "named": true
         },
@@ -5524,16 +4634,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "ALL",
-          "named": true
-        },
-        {
-          "type": "OTHERS",
-          "named": true
-        },
         {
           "type": "label",
           "named": true
@@ -5544,21 +4646,7 @@
   {
     "type": "integer_incomplete_type_definition",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "RANGE",
-          "named": true
-        },
-        {
-          "type": "box",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "interface_constant_declaration",
@@ -5568,10 +4656,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "CONSTANT",
-          "named": true
-        },
         {
           "type": "array_mode_view_indication",
           "named": true
@@ -5627,10 +4711,6 @@
       "required": true,
       "types": [
         {
-          "type": "FILE",
-          "named": true
-        },
-        {
           "type": "identifier_list",
           "named": true
         },
@@ -5649,22 +4729,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "FUNCTION",
-          "named": true
-        },
-        {
-          "type": "IMPURE",
-          "named": true
-        },
-        {
-          "type": "PURE",
-          "named": true
-        },
-        {
-          "type": "RETURN",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -5748,18 +4812,6 @@
       "required": true,
       "types": [
         {
-          "type": "IS",
-          "named": true
-        },
-        {
-          "type": "NEW",
-          "named": true
-        },
-        {
-          "type": "PACKAGE",
-          "named": true
-        },
-        {
           "type": "generic_map_any",
           "named": true
         },
@@ -5803,10 +4855,6 @@
       "required": true,
       "types": [
         {
-          "type": "PROCEDURE",
-          "named": true
-        },
-        {
           "type": "identifier",
           "named": true
         },
@@ -5842,10 +4890,6 @@
       "required": true,
       "types": [
         {
-          "type": "SIGNAL",
-          "named": true
-        },
-        {
           "type": "array_mode_view_indication",
           "named": true
         },
@@ -5873,14 +4917,6 @@
       "required": true,
       "types": [
         {
-          "type": "IS",
-          "named": true
-        },
-        {
-          "type": "box",
-          "named": true
-        },
-        {
           "type": "interface_function_specification",
           "named": true
         },
@@ -5903,14 +4939,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
-        {
-          "type": "TYPE",
-          "named": true
-        },
         {
           "type": "access_incomplete_type_definition",
           "named": true
@@ -5975,10 +5003,6 @@
       "required": true,
       "types": [
         {
-          "type": "VARIABLE",
-          "named": true
-        },
-        {
           "type": "array_mode_view_indication",
           "named": true
         },
@@ -6017,13 +5041,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "LIBRARY",
-          "named": true
-        },
         {
           "type": "logical_name_list",
           "named": true
@@ -6123,12 +5143,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "LOOP",
-          "named": true
-        },
         {
           "type": "assertion_statement",
           "named": true
@@ -6246,33 +5262,7 @@
   {
     "type": "mode",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "BUFFER",
-          "named": true
-        },
-        {
-          "type": "IN",
-          "named": true
-        },
-        {
-          "type": "INOUT",
-          "named": true
-        },
-        {
-          "type": "LINKAGE",
-          "named": true
-        },
-        {
-          "type": "OUT",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "mode_view_body",
@@ -6280,12 +5270,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
         {
           "type": "mode_view_element_definition",
           "named": true
@@ -6301,14 +5287,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "OF",
-          "named": true
-        },
-        {
-          "type": "VIEW",
-          "named": true
-        },
         {
           "type": "end_view",
           "named": true
@@ -6464,12 +5442,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "NEXT",
-          "named": true
-        },
         {
           "type": "label",
           "named": true
@@ -6490,13 +5464,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "NULL",
-          "named": true
-        },
         {
           "type": "label_declaration",
           "named": true
@@ -6512,10 +5482,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "PACKAGE",
-          "named": true
-        },
         {
           "type": "end_package",
           "named": true
@@ -6549,12 +5515,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
         {
           "type": "alias_declaration",
           "named": true
@@ -6647,14 +5609,6 @@
       "required": true,
       "types": [
         {
-          "type": "BODY",
-          "named": true
-        },
-        {
-          "type": "PACKAGE",
-          "named": true
-        },
-        {
           "type": "end_package_body",
           "named": true
         },
@@ -6687,12 +5641,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
         {
           "type": "alias_declaration",
           "named": true
@@ -6792,18 +5742,6 @@
       "required": true,
       "types": [
         {
-          "type": "IS",
-          "named": true
-        },
-        {
-          "type": "NEW",
-          "named": true
-        },
-        {
-          "type": "PACKAGE",
-          "named": true
-        },
-        {
           "type": "generic_map_aspect",
           "named": true
         },
@@ -6862,13 +5800,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "PARAMETER",
-          "named": true
-        },
         {
           "type": "interface_list",
           "named": true
@@ -6884,10 +5818,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "IN",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -7042,21 +5972,7 @@
   {
     "type": "physical_incomplete_type_definition",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "UNITS",
-          "named": true
-        },
-        {
-          "type": "box",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "physical_type_definition",
@@ -7066,10 +5982,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "UNITS",
-          "named": true
-        },
         {
           "type": "end_units",
           "named": true
@@ -7094,13 +6006,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "PORT",
-          "named": true
-        },
         {
           "type": "interface_list",
           "named": true
@@ -7113,17 +6021,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "MAP",
-          "named": true
-        },
-        {
-          "type": "PORT",
-          "named": true
-        },
         {
           "type": "association_list",
           "named": true
@@ -7161,30 +6061,16 @@
   {
     "type": "private_incomplete_type_definition",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "PRIVATE",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "private_variable_declaration",
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "PRIVATE",
-          "named": true
-        },
         {
           "type": "variable_declaration",
           "named": true
@@ -7219,10 +6105,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "PROCEDURE",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -7260,12 +6142,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
         {
           "type": "alias_declaration",
           "named": true
@@ -7346,14 +6224,6 @@
       "required": true,
       "types": [
         {
-          "type": "POSTPONED",
-          "named": true
-        },
-        {
-          "type": "PROCESS",
-          "named": true
-        },
-        {
           "type": "end_process",
           "named": true
         },
@@ -7403,14 +6273,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "BODY",
-          "named": true
-        },
-        {
-          "type": "PROTECTED",
-          "named": true
-        },
         {
           "type": "alias_declaration",
           "named": true
@@ -7491,21 +6353,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "BODY",
-          "named": true
-        },
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "PROTECTED",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -7533,10 +6383,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "PROTECTED",
-          "named": true
-        },
         {
           "type": "alias_declaration",
           "named": true
@@ -7577,17 +6423,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "PROTECTED",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -7635,10 +6473,6 @@
       "required": true,
       "types": [
         {
-          "type": "NEW",
-          "named": true
-        },
-        {
           "type": "generic_map_aspect",
           "named": true
         },
@@ -7654,13 +6488,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "RANGE",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -7755,14 +6585,6 @@
       "required": true,
       "types": [
         {
-          "type": "OF",
-          "named": true
-        },
-        {
-          "type": "VIEW",
-          "named": true
-        },
-        {
           "type": "name",
           "named": true
         },
@@ -7796,10 +6618,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "RECORD",
-          "named": true
-        },
         {
           "type": "element_declaration",
           "named": true
@@ -7871,13 +6689,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "REPORT",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -7953,12 +6767,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "RETURN",
-          "named": true
-        },
         {
           "type": "conditional_or_unaffected_expression",
           "named": true
@@ -7977,17 +6787,7 @@
   {
     "type": "scalar_incomplete_type_definition",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "box",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "secondary_unit_declaration",
@@ -8041,13 +6841,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "SELECT",
-          "named": true
-        },
         {
           "type": "aggregate",
           "named": true
@@ -8103,10 +6899,6 @@
       "required": true,
       "types": [
         {
-          "type": "FORCE",
-          "named": true
-        },
-        {
           "type": "force_mode",
           "named": true
         },
@@ -8141,10 +6933,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "ALL",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -8274,12 +7062,8 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "ALL",
-          "named": true
-        },
         {
           "type": "character_literal",
           "named": true
@@ -8300,13 +7084,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "ON",
-          "named": true
-        },
         {
           "type": "sensitivity_list",
           "named": true
@@ -8335,12 +7115,8 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "ALL",
-          "named": true
-        },
         {
           "type": "sensitivity_list",
           "named": true
@@ -8354,12 +7130,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "BEGIN",
-          "named": true
-        },
         {
           "type": "assertion_statement",
           "named": true
@@ -8449,12 +7221,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
         {
           "type": "alias_declaration",
           "named": true
@@ -8535,10 +7303,6 @@
       "required": true,
       "types": [
         {
-          "type": "BLOCK",
-          "named": true
-        },
-        {
           "type": "end_block",
           "named": true
         },
@@ -8562,13 +7326,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "SEVERITY",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -8651,10 +7411,6 @@
       "required": true,
       "types": [
         {
-          "type": "SIGNAL",
-          "named": true
-        },
-        {
           "type": "identifier_list",
           "named": true
         },
@@ -8676,21 +7432,7 @@
   {
     "type": "signal_kind",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "BUS",
-          "named": true
-        },
-        {
-          "type": "REGISTER",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "signal_list",
@@ -8698,16 +7440,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "ALL",
-          "named": true
-        },
-        {
-          "type": "OTHERS",
-          "named": true
-        },
         {
           "type": "name",
           "named": true
@@ -8724,10 +7458,6 @@
       "required": false,
       "types": [
         {
-          "type": "RETURN",
-          "named": true
-        },
-        {
           "type": "name",
           "named": true
         }
@@ -8740,12 +7470,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "NULL",
-          "named": true
-        },
         {
           "type": "adding_operator",
           "named": true
@@ -8862,10 +7588,6 @@
       "required": true,
       "types": [
         {
-          "type": "FORCE",
-          "named": true
-        },
-        {
           "type": "aggregate",
           "named": true
         },
@@ -8901,10 +7623,6 @@
       "required": true,
       "types": [
         {
-          "type": "BUS",
-          "named": true
-        },
-        {
           "type": "initialiser",
           "named": true
         },
@@ -8932,14 +7650,6 @@
       "required": true,
       "types": [
         {
-          "type": "DOWNTO",
-          "named": true
-        },
-        {
-          "type": "TO",
-          "named": true
-        },
-        {
           "type": "simple_expression",
           "named": true
         }
@@ -8954,10 +7664,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "RELEASE",
-          "named": true
-        },
         {
           "type": "aggregate",
           "named": true
@@ -9102,21 +7808,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "END",
-          "named": true
-        },
-        {
-          "type": "FUNCTION",
-          "named": true
-        },
-        {
-          "type": "PROCEDURE",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -9146,12 +7840,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
         {
           "type": "alias_declaration",
           "named": true
@@ -9232,10 +7922,6 @@
       "required": true,
       "types": [
         {
-          "type": "GENERIC",
-          "named": true
-        },
-        {
           "type": "generic_map_aspect",
           "named": true
         },
@@ -9254,22 +7940,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "FUNCTION",
-          "named": true
-        },
-        {
-          "type": "IS",
-          "named": true
-        },
-        {
-          "type": "NEW",
-          "named": true
-        },
-        {
-          "type": "PROCEDURE",
-          "named": true
-        },
         {
           "type": "generic_map_aspect",
           "named": true
@@ -9313,14 +7983,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
-        {
-          "type": "SUBTYPE",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
@@ -9372,13 +8034,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "FOR",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -9410,14 +8068,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
-        {
-          "type": "TYPE",
-          "named": true
-        },
         {
           "type": "access_type_definition",
           "named": true
@@ -9487,17 +8137,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "IS",
-          "named": true
-        },
-        {
-          "type": "TYPE",
-          "named": true
-        },
         {
           "type": "access_incomplete_type_definition",
           "named": true
@@ -9546,10 +8188,6 @@
       "required": true,
       "types": [
         {
-          "type": "USE",
-          "named": true
-        },
-        {
           "type": "selected_name",
           "named": true
         }
@@ -9596,14 +8234,6 @@
       "required": true,
       "types": [
         {
-          "type": "SHARED",
-          "named": true
-        },
-        {
-          "type": "VARIABLE",
-          "named": true
-        },
-        {
           "type": "generic_map_aspect",
           "named": true
         },
@@ -9627,17 +8257,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "USE",
-          "named": true
-        },
-        {
-          "type": "VUNIT",
-          "named": true
-        },
         {
           "type": "verification_unit_list",
           "named": true
@@ -9666,12 +8288,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "WAIT",
-          "named": true
-        },
         {
           "type": "condition_clause",
           "named": true
@@ -9716,12 +8334,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "UNAFFECTED",
-          "named": true
-        },
         {
           "type": "waveform_element",
           "named": true
@@ -9737,10 +8351,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "AFTER",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -9769,17 +8379,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
-        {
-          "type": "OTHERS",
-          "named": true
-        },
-        {
-          "type": "WHEN",
-          "named": true
-        },
         {
           "type": "choices",
           "named": true
@@ -9816,13 +8418,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "WHEN",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -9851,13 +8449,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "WHILE",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -9886,13 +8480,9 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "WITH",
-          "named": true
-        },
         {
           "type": "condition_expression",
           "named": true
@@ -9981,6 +8571,10 @@
     "named": false
   },
   {
+    "type": "<>",
+    "named": false
+  },
+  {
     "type": "=",
     "named": false
   },
@@ -10033,374 +8627,6 @@
     "named": false
   },
   {
-    "type": "ACCESS",
-    "named": true
-  },
-  {
-    "type": "AFTER",
-    "named": true
-  },
-  {
-    "type": "ALIAS",
-    "named": true
-  },
-  {
-    "type": "ALL",
-    "named": true
-  },
-  {
-    "type": "ARCHITECTURE",
-    "named": true
-  },
-  {
-    "type": "ARRAY",
-    "named": true
-  },
-  {
-    "type": "ASSERT",
-    "named": true
-  },
-  {
-    "type": "ATTRIBUTE",
-    "named": true
-  },
-  {
-    "type": "BEGIN",
-    "named": true
-  },
-  {
-    "type": "BLOCK",
-    "named": true
-  },
-  {
-    "type": "BODY",
-    "named": true
-  },
-  {
-    "type": "BUFFER",
-    "named": true
-  },
-  {
-    "type": "BUS",
-    "named": true
-  },
-  {
-    "type": "CASE",
-    "named": true
-  },
-  {
-    "type": "COMPONENT",
-    "named": true
-  },
-  {
-    "type": "CONFIGURATION",
-    "named": true
-  },
-  {
-    "type": "CONSTANT",
-    "named": true
-  },
-  {
-    "type": "CONTEXT",
-    "named": true
-  },
-  {
-    "type": "DEFAULT",
-    "named": true
-  },
-  {
-    "type": "DISCONNECT",
-    "named": true
-  },
-  {
-    "type": "DOWNTO",
-    "named": true
-  },
-  {
-    "type": "ELSE",
-    "named": true
-  },
-  {
-    "type": "ELSIF",
-    "named": true
-  },
-  {
-    "type": "END",
-    "named": true
-  },
-  {
-    "type": "ENTITY",
-    "named": true
-  },
-  {
-    "type": "EXIT",
-    "named": true
-  },
-  {
-    "type": "FILE",
-    "named": true
-  },
-  {
-    "type": "FOR",
-    "named": true
-  },
-  {
-    "type": "FORCE",
-    "named": true
-  },
-  {
-    "type": "FUNCTION",
-    "named": true
-  },
-  {
-    "type": "GENERATE",
-    "named": true
-  },
-  {
-    "type": "GENERIC",
-    "named": true
-  },
-  {
-    "type": "GROUP",
-    "named": true
-  },
-  {
-    "type": "GUARDED",
-    "named": true
-  },
-  {
-    "type": "IF",
-    "named": true
-  },
-  {
-    "type": "IMPURE",
-    "named": true
-  },
-  {
-    "type": "IN",
-    "named": true
-  },
-  {
-    "type": "INERTIAL",
-    "named": true
-  },
-  {
-    "type": "INOUT",
-    "named": true
-  },
-  {
-    "type": "IS",
-    "named": true
-  },
-  {
-    "type": "LABEL",
-    "named": true
-  },
-  {
-    "type": "LIBRARY",
-    "named": true
-  },
-  {
-    "type": "LINKAGE",
-    "named": true
-  },
-  {
-    "type": "LITERAL",
-    "named": true
-  },
-  {
-    "type": "LOOP",
-    "named": true
-  },
-  {
-    "type": "MAP",
-    "named": true
-  },
-  {
-    "type": "NEW",
-    "named": true
-  },
-  {
-    "type": "NEXT",
-    "named": true
-  },
-  {
-    "type": "NULL",
-    "named": true
-  },
-  {
-    "type": "OF",
-    "named": true
-  },
-  {
-    "type": "ON",
-    "named": true
-  },
-  {
-    "type": "OPEN",
-    "named": true
-  },
-  {
-    "type": "OTHERS",
-    "named": true
-  },
-  {
-    "type": "OUT",
-    "named": true
-  },
-  {
-    "type": "PACKAGE",
-    "named": true
-  },
-  {
-    "type": "PARAMETER",
-    "named": true
-  },
-  {
-    "type": "PORT",
-    "named": true
-  },
-  {
-    "type": "POSTPONED",
-    "named": true
-  },
-  {
-    "type": "PRIVATE",
-    "named": true
-  },
-  {
-    "type": "PROCEDURE",
-    "named": true
-  },
-  {
-    "type": "PROCESS",
-    "named": true
-  },
-  {
-    "type": "PROPERTY",
-    "named": true
-  },
-  {
-    "type": "PROTECTED",
-    "named": true
-  },
-  {
-    "type": "PURE",
-    "named": true
-  },
-  {
-    "type": "RANGE",
-    "named": true
-  },
-  {
-    "type": "RECORD",
-    "named": true
-  },
-  {
-    "type": "REGISTER",
-    "named": true
-  },
-  {
-    "type": "REJECT",
-    "named": true
-  },
-  {
-    "type": "RELEASE",
-    "named": true
-  },
-  {
-    "type": "REPORT",
-    "named": true
-  },
-  {
-    "type": "RETURN",
-    "named": true
-  },
-  {
-    "type": "SELECT",
-    "named": true
-  },
-  {
-    "type": "SEQUENCE",
-    "named": true
-  },
-  {
-    "type": "SEVERITY",
-    "named": true
-  },
-  {
-    "type": "SHARED",
-    "named": true
-  },
-  {
-    "type": "SIGNAL",
-    "named": true
-  },
-  {
-    "type": "SUBTYPE",
-    "named": true
-  },
-  {
-    "type": "THEN",
-    "named": true
-  },
-  {
-    "type": "TO",
-    "named": true
-  },
-  {
-    "type": "TRANSPORT",
-    "named": true
-  },
-  {
-    "type": "TYPE",
-    "named": true
-  },
-  {
-    "type": "UNAFFECTED",
-    "named": true
-  },
-  {
-    "type": "UNITS",
-    "named": true
-  },
-  {
-    "type": "UNTIL",
-    "named": true
-  },
-  {
-    "type": "USE",
-    "named": true
-  },
-  {
-    "type": "VARIABLE",
-    "named": true
-  },
-  {
-    "type": "VIEW",
-    "named": true
-  },
-  {
-    "type": "VUNIT",
-    "named": true
-  },
-  {
-    "type": "WAIT",
-    "named": true
-  },
-  {
-    "type": "WHEN",
-    "named": true
-  },
-  {
-    "type": "WHILE",
-    "named": true
-  },
-  {
-    "type": "WITH",
-    "named": true
-  },
-  {
     "type": "[",
     "named": false
   },
@@ -10410,6 +8636,38 @@
   },
   {
     "type": "^",
+    "named": false
+  },
+  {
+    "type": "access",
+    "named": false
+  },
+  {
+    "type": "after",
+    "named": false
+  },
+  {
+    "type": "alias",
+    "named": false
+  },
+  {
+    "type": "all",
+    "named": false
+  },
+  {
+    "type": "architecture",
+    "named": false
+  },
+  {
+    "type": "array",
+    "named": false
+  },
+  {
+    "type": "assert",
+    "named": false
+  },
+  {
+    "type": "attribute",
     "named": false
   },
   {
@@ -10465,6 +8723,10 @@
     "named": true
   },
   {
+    "type": "begin",
+    "named": false
+  },
+  {
     "type": "bit_string_base",
     "named": true
   },
@@ -10477,8 +8739,24 @@
     "named": true
   },
   {
-    "type": "box",
-    "named": true
+    "type": "block",
+    "named": false
+  },
+  {
+    "type": "body",
+    "named": false
+  },
+  {
+    "type": "buffer",
+    "named": false
+  },
+  {
+    "type": "bus",
+    "named": false
+  },
+  {
+    "type": "case",
+    "named": false
   },
   {
     "type": "character_literal",
@@ -10489,8 +8767,24 @@
     "named": true
   },
   {
+    "type": "component",
+    "named": false
+  },
+  {
     "type": "condition_conversion",
     "named": true
+  },
+  {
+    "type": "configuration",
+    "named": false
+  },
+  {
+    "type": "constant",
+    "named": false
+  },
+  {
+    "type": "context",
+    "named": false
   },
   {
     "type": "decimal_float",
@@ -10499,6 +8793,10 @@
   {
     "type": "decimal_integer",
     "named": true
+  },
+  {
+    "type": "default",
+    "named": false
   },
   {
     "type": "directive_body",
@@ -10521,16 +8819,108 @@
     "named": true
   },
   {
+    "type": "disconnect",
+    "named": false
+  },
+  {
+    "type": "downto",
+    "named": false
+  },
+  {
+    "type": "else",
+    "named": false
+  },
+  {
+    "type": "elsif",
+    "named": false
+  },
+  {
+    "type": "end",
+    "named": false
+  },
+  {
+    "type": "entity",
+    "named": false
+  },
+  {
+    "type": "exit",
+    "named": false
+  },
+  {
     "type": "exponentiate",
     "named": true
+  },
+  {
+    "type": "file",
+    "named": false
+  },
+  {
+    "type": "for",
+    "named": false
+  },
+  {
+    "type": "force",
+    "named": false
+  },
+  {
+    "type": "function",
+    "named": false
+  },
+  {
+    "type": "generate",
+    "named": false
+  },
+  {
+    "type": "generic",
+    "named": false
+  },
+  {
+    "type": "group",
+    "named": false
+  },
+  {
+    "type": "guarded",
+    "named": false
   },
   {
     "type": "identifier",
     "named": true
   },
   {
+    "type": "if",
+    "named": false
+  },
+  {
+    "type": "impure",
+    "named": false
+  },
+  {
+    "type": "in",
+    "named": false
+  },
+  {
+    "type": "inertial",
+    "named": false
+  },
+  {
+    "type": "inout",
+    "named": false
+  },
+  {
+    "type": "is",
+    "named": false
+  },
+  {
+    "type": "label",
+    "named": false
+  },
+  {
     "type": "label",
     "named": true
+  },
+  {
+    "type": "library",
+    "named": false
   },
   {
     "type": "library_attribute",
@@ -10581,8 +8971,144 @@
     "named": true
   },
   {
+    "type": "linkage",
+    "named": false
+  },
+  {
+    "type": "literal",
+    "named": false
+  },
+  {
+    "type": "loop",
+    "named": false
+  },
+  {
+    "type": "map",
+    "named": false
+  },
+  {
+    "type": "new",
+    "named": false
+  },
+  {
+    "type": "next",
+    "named": false
+  },
+  {
+    "type": "null",
+    "named": false
+  },
+  {
+    "type": "of",
+    "named": false
+  },
+  {
+    "type": "on",
+    "named": false
+  },
+  {
+    "type": "open",
+    "named": false
+  },
+  {
     "type": "operator_symbol",
     "named": true
+  },
+  {
+    "type": "others",
+    "named": false
+  },
+  {
+    "type": "out",
+    "named": false
+  },
+  {
+    "type": "package",
+    "named": false
+  },
+  {
+    "type": "parameter",
+    "named": false
+  },
+  {
+    "type": "port",
+    "named": false
+  },
+  {
+    "type": "postponed",
+    "named": false
+  },
+  {
+    "type": "private",
+    "named": false
+  },
+  {
+    "type": "procedure",
+    "named": false
+  },
+  {
+    "type": "process",
+    "named": false
+  },
+  {
+    "type": "property",
+    "named": false
+  },
+  {
+    "type": "protected",
+    "named": false
+  },
+  {
+    "type": "pure",
+    "named": false
+  },
+  {
+    "type": "range",
+    "named": false
+  },
+  {
+    "type": "record",
+    "named": false
+  },
+  {
+    "type": "register",
+    "named": false
+  },
+  {
+    "type": "reject",
+    "named": false
+  },
+  {
+    "type": "release",
+    "named": false
+  },
+  {
+    "type": "report",
+    "named": false
+  },
+  {
+    "type": "return",
+    "named": false
+  },
+  {
+    "type": "select",
+    "named": false
+  },
+  {
+    "type": "sequence",
+    "named": false
+  },
+  {
+    "type": "severity",
+    "named": false
+  },
+  {
+    "type": "shared",
+    "named": false
+  },
+  {
+    "type": "signal",
+    "named": false
   },
   {
     "type": "string_literal",
@@ -10593,12 +9119,76 @@
     "named": true
   },
   {
+    "type": "subtype",
+    "named": false
+  },
+  {
+    "type": "then",
+    "named": false
+  },
+  {
+    "type": "to",
+    "named": false
+  },
+  {
+    "type": "transport",
+    "named": false
+  },
+  {
+    "type": "type",
+    "named": false
+  },
+  {
+    "type": "unaffected",
+    "named": false
+  },
+  {
     "type": "unit",
     "named": true
   },
   {
+    "type": "units",
+    "named": false
+  },
+  {
+    "type": "until",
+    "named": false
+  },
+  {
+    "type": "use",
+    "named": false
+  },
+  {
+    "type": "variable",
+    "named": false
+  },
+  {
     "type": "variable_assignment",
     "named": true
+  },
+  {
+    "type": "view",
+    "named": false
+  },
+  {
+    "type": "vunit",
+    "named": false
+  },
+  {
+    "type": "wait",
+    "named": false
+  },
+  {
+    "type": "when",
+    "named": false
+  },
+  {
+    "type": "while",
+    "named": false
+  },
+  {
+    "type": "with",
+    "named": false
   },
   {
     "type": "|",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -432,8 +432,12 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
+        {
+          "type": "OPEN",
+          "named": true
+        },
         {
           "type": "conditional_expression",
           "named": true
@@ -968,6 +972,10 @@
       "required": true,
       "types": [
         {
+          "type": "OTHERS",
+          "named": true
+        },
+        {
           "type": "case_generate_body",
           "named": true
         },
@@ -1373,8 +1381,12 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
+        {
+          "type": "OTHERS",
+          "named": true
+        },
         {
           "type": "choices",
           "named": true
@@ -2473,6 +2485,10 @@
       "required": true,
       "types": [
         {
+          "type": "OTHERS",
+          "named": true
+        },
+        {
           "type": "choices",
           "named": true
         },
@@ -3137,8 +3153,12 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
+        {
+          "type": "OPEN",
+          "named": true
+        },
         {
           "type": "identifier",
           "named": true
@@ -3388,8 +3408,16 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
+        {
+          "type": "ALL",
+          "named": true
+        },
+        {
+          "type": "OTHERS",
+          "named": true
+        },
         {
           "type": "entity_designator",
           "named": true
@@ -3670,6 +3698,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "OPEN",
+          "named": true
+        },
         {
           "type": "condition_expression",
           "named": true
@@ -4115,7 +4147,17 @@
   {
     "type": "generic_map_default",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "DEFAULT",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "group_constituent_list",
@@ -4634,8 +4676,16 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
+        {
+          "type": "ALL",
+          "named": true
+        },
+        {
+          "type": "OTHERS",
+          "named": true
+        },
         {
           "type": "label",
           "named": true
@@ -6934,6 +6984,10 @@
       "required": true,
       "types": [
         {
+          "type": "ALL",
+          "named": true
+        },
+        {
           "type": "identifier",
           "named": true
         },
@@ -7062,8 +7116,12 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
+        {
+          "type": "ALL",
+          "named": true
+        },
         {
           "type": "character_literal",
           "named": true
@@ -7115,8 +7173,12 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
+        {
+          "type": "ALL",
+          "named": true
+        },
         {
           "type": "sensitivity_list",
           "named": true
@@ -7440,8 +7502,16 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
+        {
+          "type": "ALL",
+          "named": true
+        },
+        {
+          "type": "OTHERS",
+          "named": true
+        },
         {
           "type": "name",
           "named": true
@@ -8380,8 +8450,12 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
+        {
+          "type": "OTHERS",
+          "named": true
+        },
         {
           "type": "choices",
           "named": true
@@ -8627,6 +8701,22 @@
     "named": false
   },
   {
+    "type": "ALL",
+    "named": true
+  },
+  {
+    "type": "DEFAULT",
+    "named": true
+  },
+  {
+    "type": "OPEN",
+    "named": true
+  },
+  {
+    "type": "OTHERS",
+    "named": true
+  },
+  {
     "type": "[",
     "named": false
   },
@@ -8648,10 +8738,6 @@
   },
   {
     "type": "alias",
-    "named": false
-  },
-  {
-    "type": "all",
     "named": false
   },
   {
@@ -8793,10 +8879,6 @@
   {
     "type": "decimal_integer",
     "named": true
-  },
-  {
-    "type": "default",
-    "named": false
   },
   {
     "type": "directive_body",
@@ -9007,16 +9089,8 @@
     "named": false
   },
   {
-    "type": "open",
-    "named": false
-  },
-  {
     "type": "operator_symbol",
     "named": true
-  },
-  {
-    "type": "others",
-    "named": false
   },
   {
     "type": "out",

--- a/test/corpus/architecture_basic.vhd
+++ b/test/corpus/architecture_basic.vhd
@@ -20,14 +20,14 @@ end EXAMPLE;
     (comment_content))
   (design_unit
     (architecture_definition
-      (identifier)
-      (name
+      architecture: (identifier)
+      entity: (name
         (identifier))
     (architecture_head
       (subtype_declaration
-        (identifier)
+        type: (identifier)
         (subtype_indication
-          (name
+          type: (name
             (library_type))
         (range_constraint
           (simple_range
@@ -47,5 +47,5 @@ end EXAMPLE;
     (line_comment
       (comment_content))
     (end_architecture
-      (identifier)))))
+      architecture: (identifier)))))
 

--- a/test/corpus/architecture_basic.vhd
+++ b/test/corpus/architecture_basic.vhd
@@ -20,30 +20,22 @@ end EXAMPLE;
     (comment_content))
   (design_unit
     (architecture_definition
-      (ARCHITECTURE)
       (identifier)
-      (OF)
       (name
       (identifier))
     (architecture_head
-      (IS)
       (subtype_declaration
-        (SUBTYPE)
         (identifier)
-        (IS)
         (subtype_indication
           (name
           (library_type))
         (range_constraint
-          (RANGE)
           (simple_range
             (simple_expression
               (decimal_integer))
-            (TO)
             (simple_expression
               (decimal_integer)))))))
     (concurrent_block
-      (BEGIN)
       (concurrent_simple_signal_assignment
         (name
         (identifier))
@@ -55,6 +47,5 @@ end EXAMPLE;
     (line_comment
       (comment_content))
     (end_architecture
-      (END)
       (identifier)))))
 

--- a/test/corpus/entity.vhd
+++ b/test/corpus/entity.vhd
@@ -38,7 +38,7 @@ entity MyModule is port(
 (design_file
   (design_unit
     (entity_declaration
-      (identifier)
+      entity: (identifier)
       (entity_head
         (port_clause
           (interface_list
@@ -49,7 +49,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (interface_signal_declaration
               (identifier_list
@@ -57,7 +57,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (interface_signal_declaration
               (identifier_list
@@ -65,7 +65,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (interface_signal_declaration
               (identifier_list
@@ -73,17 +73,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
-                    (library_type)))))
-            (line_comment
-              (comment_content))
-            (interface_signal_declaration
-              (identifier_list
-                (identifier))
-              (simple_mode_indication
-                (mode)
-                (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (line_comment
               (comment_content))
@@ -93,7 +83,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (line_comment
               (comment_content))
@@ -103,7 +93,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (line_comment
               (comment_content))
@@ -113,7 +103,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (line_comment
               (comment_content))
@@ -123,7 +113,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (line_comment
               (comment_content))
@@ -133,7 +123,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (line_comment
               (comment_content))
@@ -143,7 +133,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (line_comment
               (comment_content))
@@ -153,7 +143,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (line_comment
               (comment_content))
@@ -163,7 +153,17 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
+                    (library_type)))))
+            (line_comment
+              (comment_content))
+            (interface_signal_declaration
+              (identifier_list
+                (identifier))
+              (simple_mode_indication
+                (mode)
+                (subtype_indication
+                  type: (name
                     (library_type)))
                 (initialiser
                   (variable_assignment)
@@ -178,7 +178,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))
                 (initialiser
                   (variable_assignment)
@@ -193,7 +193,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))
                 (initialiser
                   (variable_assignment)
@@ -236,7 +236,7 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type))
                   (range_constraint
                     (simple_range
@@ -250,21 +250,20 @@ entity MyModule is port(
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)
-                    (name_selector
-                      (parenthesis_group
-                        (association_or_range_list
-                          (simple_range
-                            (simple_expression
-                              (decimal_integer))
-                            (simple_expression
-                              (decimal_integer)))
-                          (simple_range
-                            (simple_expression
-                              (decimal_integer))
-                            (simple_expression
-                              (decimal_integer))))))))))
+                    (parenthesis_group
+                      (association_or_range_list
+                        (simple_range
+                          (simple_expression
+                            (decimal_integer))
+                          (simple_expression
+                            (decimal_integer)))
+                        (simple_range
+                          (simple_expression
+                            (decimal_integer))
+                          (simple_expression
+                            (decimal_integer)))))))))
             (interface_signal_declaration
               (identifier_list
                 (identifier))
@@ -274,8 +273,8 @@ entity MyModule is port(
                   (resolution_indication
                     (name
                       (library_function)))
-                  (name
+                  type: (name
                     (library_type))))))))
       (end_entity
-        (identifier)))))
+        entity: (identifier)))))
 

--- a/test/corpus/entity.vhd
+++ b/test/corpus/entity.vhd
@@ -38,159 +38,130 @@ entity MyModule is port(
 (design_file
   (design_unit
     (entity_declaration
-      (ENTITY)
       (identifier)
       (entity_head
-        (IS)
         (port_clause
-          (PORT)
           (interface_list
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier)
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (OUT))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (INOUT))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (INOUT))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
             (line_comment
               (comment_content))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (INOUT))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
             (line_comment
               (comment_content))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (INOUT))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
             (line_comment
               (comment_content))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (INOUT))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
             (line_comment
               (comment_content))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (INOUT))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
             (line_comment
               (comment_content))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (INOUT))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
             (line_comment
               (comment_content))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (INOUT))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
             (line_comment
               (comment_content))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (OUT))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
             (line_comment
               (comment_content))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (OUT))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
             (line_comment
               (comment_content))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))
@@ -202,12 +173,10 @@ entity MyModule is port(
                         (bit_string_base)
                         (bit_string_value)))))))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))
@@ -219,12 +188,10 @@ entity MyModule is port(
                         (based_base)
                         (based_integer)))))))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))
@@ -247,52 +214,41 @@ entity MyModule is port(
               (directive_body)
               (directive_body))
             (if_conditional_analysis
-              (IF)
               (conditional_analysis_expression
                 (conditional_analysis_relation
                   (library_function)
-                  (string_literal)))
-              (THEN))
+                  (string_literal))))
             (warning_directive
               (directive_warning)
               (string_literal))
-            (else_conditional_analysis
-              (ELSE))
+            (else_conditional_analysis)
             (error_directive
               (directive_error)
               (string_literal))
-            (end_conditional_analysis
-              (END)
-              (IF))
+            (end_conditional_analysis)
             (protect_directive
               (directive_protect)
               (directive_body)
               (directive_body))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type))
                   (range_constraint
-                    (RANGE)
                     (simple_range
                       (simple_expression
                         (decimal_integer))
-                      (TO)
                       (simple_expression
                         (decimal_integer)))))))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)
@@ -302,22 +258,18 @@ entity MyModule is port(
                           (simple_range
                             (simple_expression
                               (decimal_integer))
-                            (DOWNTO)
                             (simple_expression
                               (decimal_integer)))
                           (simple_range
                             (simple_expression
                               (decimal_integer))
-                            (DOWNTO)
                             (simple_expression
                               (decimal_integer))))))))))
             (interface_signal_declaration
-              (SIGNAL)
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (resolution_indication
                     (name
@@ -325,7 +277,5 @@ entity MyModule is port(
                   (name
                     (library_type))))))))
       (end_entity
-        (END)
-        (ENTITY)
         (identifier)))))
 

--- a/test/corpus/if_generate.vhd
+++ b/test/corpus/if_generate.vhd
@@ -18,7 +18,6 @@ end generate testGenerate;
       (label_declaration
         (label))
       (if_generate
-        (IF)
         (relational_expression
           (simple_expression
             (name
@@ -28,7 +27,6 @@ end generate testGenerate;
             (decimal_integer)))
         (generate_body
           (generate_direct_block
-            (GENERATE)
             (concurrent_simple_signal_assignment
               (name
                 (identifier))
@@ -44,7 +42,6 @@ end generate testGenerate;
                       (name
                         (identifier))))))))))
       (elsif_generate
-        (ELSIF)
         (relational_expression
           (simple_expression
             (name
@@ -54,7 +51,6 @@ end generate testGenerate;
             (decimal_integer)))
         (generate_body
           (generate_direct_block
-            (GENERATE)
             (concurrent_simple_signal_assignment
               (name
                 (identifier))
@@ -70,10 +66,8 @@ end generate testGenerate;
                       (name
                         (identifier))))))))))
       (else_generate
-        (ELSE)
         (generate_body
           (generate_direct_block
-            (GENERATE)
             (concurrent_simple_signal_assignment
               (name
                 (identifier))
@@ -89,7 +83,5 @@ end generate testGenerate;
                       (name
                         (identifier))))))))))
       (end_generate
-        (END)
-        (GENERATE)
         (label)))))
 

--- a/test/corpus/if_statement.vhd
+++ b/test/corpus/if_statement.vhd
@@ -19,14 +19,10 @@ end process;
 (design_file
   (design_unit
     (process_statement
-      (PROCESS)
-      (sensitivity_specification
-        (ALL))
+      (sensitivity_specification)
       (sequential_block
-        (BEGIN)
         (if_statement_block
           (if_statement
-            (IF)
             (relational_expression
               (simple_expression
                 (name
@@ -34,7 +30,6 @@ end process;
               (relational_operator)
               (simple_expression
                 (decimal_integer)))
-            (THEN)
             (if_statement_body
               (simple_waveform_assignment
                 (name
@@ -51,7 +46,6 @@ end process;
                         (name
                           (identifier)))))))))
           (elsif_statement
-            (ELSIF)
             (relational_expression
               (simple_expression
                 (name
@@ -59,7 +53,6 @@ end process;
               (relational_operator)
               (simple_expression
                 (decimal_integer)))
-            (THEN)
             (if_statement_body
               (simple_waveform_assignment
                 (name
@@ -76,7 +69,6 @@ end process;
                         (name
                           (identifier)))))))))
           (elsif_statement
-            (ELSIF)
             (relational_expression
               (simple_expression
                 (name
@@ -84,7 +76,6 @@ end process;
               (relational_operator)
               (simple_expression
                 (decimal_integer)))
-            (THEN)
             (if_statement_body
               (simple_waveform_assignment
                 (name
@@ -101,7 +92,6 @@ end process;
                         (name
                           (identifier)))))))))
           (else_statement
-            (ELSE)
             (if_statement_body
               (simple_waveform_assignment
                 (name
@@ -117,10 +107,6 @@ end process;
                       (simple_expression
                         (name
                           (identifier)))))))))
-          (end_if
-            (END)
-            (IF))))
-      (end_process
-        (END)
-        (PROCESS)))))
+          (end_if)))
+      (end_process))))
 

--- a/test/corpus/if_statement.vhd
+++ b/test/corpus/if_statement.vhd
@@ -19,7 +19,8 @@ end process;
 (design_file
   (design_unit
     (process_statement
-      (sensitivity_specification)
+      (sensitivity_specification
+        (ALL))
       (sequential_block
         (if_statement_block
           (if_statement

--- a/test/corpus/library_constant_break.vhd
+++ b/test/corpus/library_constant_break.vhd
@@ -13,15 +13,11 @@ end Behaviour;
 (design_file
   (design_unit
     (architecture_definition
-      (ARCHITECTURE)
       (identifier)
-      (OF)
       (name
         (identifier))
-      (architecture_head
-        (IS))
+      (architecture_head)
       (concurrent_block
-        (BEGIN)
         (concurrent_simple_signal_assignment
           (name
             (identifier))
@@ -47,6 +43,5 @@ end Behaviour;
                     (selection
                       (identifier)))))))))
       (end_architecture
-        (END)
         (identifier)))))
 

--- a/test/corpus/library_constant_break.vhd
+++ b/test/corpus/library_constant_break.vhd
@@ -13,8 +13,8 @@ end Behaviour;
 (design_file
   (design_unit
     (architecture_definition
-      (identifier)
-      (name
+      architecture: (identifier)
+      entity: (name
         (identifier))
       (architecture_head)
       (concurrent_block
@@ -27,9 +27,8 @@ end Behaviour;
               (simple_expression
                 (name
                   (library_constant)
-                  (name_selector
-                    (selection
-                      (identifier))))))))
+                  (selection
+                    (identifier)))))))
         (concurrent_simple_signal_assignment
           (name
             (identifier))
@@ -39,9 +38,8 @@ end Behaviour;
               (simple_expression
                 (name
                   (library_constant)
-                  (name_selector
-                    (selection
-                      (identifier)))))))))
+                  (selection
+                    (identifier))))))))
       (end_architecture
-        (identifier)))))
+        architecture: (identifier)))))
 

--- a/test/corpus/literals.vhd
+++ b/test/corpus/literals.vhd
@@ -514,6 +514,5 @@ A <= null;
       (signal_assignment)
       (waveform
         (waveform_element
-          (simple_expression
-            (NULL)))))))
+          (simple_expression))))))
 

--- a/test/corpus/specification_examples/architecture.vhd
+++ b/test/corpus/specification_examples/architecture.vhd
@@ -101,21 +101,24 @@ end architecture DataFlow;
     (use_clause
       (selected_name
         (library_namespace)
-        (identifier)))
+        (identifier)
+        (ALL)))
     (library_clause
       (logical_name_list
         (library_namespace)))
     (use_clause
       (selected_name
         (library_namespace)
-        (identifier)))
+        (identifier)
+        (ALL)))
     (library_clause
       (logical_name_list
         (library_namespace)))
     (use_clause
       (selected_name
         (library_namespace)
-        (identifier)))
+        (identifier)
+        (ALL)))
     (entity_declaration
       (identifier)
       (entity_head
@@ -919,7 +922,8 @@ end architecture DataFlow;
                               (name
                                 (library_constant_std_logic)))))))
                     (case_statement_alternative
-                      (when_element)
+                      (when_element
+                        (OTHERS))
                       (simple_waveform_assignment
                         (name
                           (identifier)

--- a/test/corpus/specification_examples/architecture.vhd
+++ b/test/corpus/specification_examples/architecture.vhd
@@ -97,30 +97,30 @@ end architecture DataFlow;
   (design_unit
     (library_clause
       (logical_name_list
-        (library_namespace)))
+        library: (library_namespace)))
     (use_clause
       (selected_name
-        (library_namespace)
+        library: (library_namespace)
         (identifier)
         (ALL)))
     (library_clause
       (logical_name_list
-        (library_namespace)))
+        library: (library_namespace)))
     (use_clause
       (selected_name
-        (library_namespace)
+        library: (library_namespace)
         (identifier)
         (ALL)))
     (library_clause
       (logical_name_list
-        (library_namespace)))
+        library: (library_namespace)))
     (use_clause
       (selected_name
-        (library_namespace)
+        library: (library_namespace)
         (identifier)
         (ALL)))
     (entity_declaration
-      (identifier)
+      entity: (identifier)
       (entity_head
         (port_clause
           (interface_list
@@ -130,7 +130,7 @@ end architecture DataFlow;
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (interface_declaration
               (identifier_list
@@ -138,16 +138,16 @@ end architecture DataFlow;
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type))))))))
       (end_entity
-        (identifier))))
+        entity: (identifier))))
   (line_comment
     (comment_content))
   (design_unit
     (architecture_definition
-      (identifier)
-      (name
+      architecture: (identifier)
+      entity: (name
         (identifier))
       (architecture_head
         (signal_declaration
@@ -155,11 +155,11 @@ end architecture DataFlow;
             (identifier)
             (identifier))
           (subtype_indication
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -167,13 +167,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -181,13 +181,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -195,13 +195,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -209,13 +209,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -223,13 +223,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -237,13 +237,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -251,13 +251,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -265,13 +265,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -279,13 +279,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -293,13 +293,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -307,13 +307,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -321,13 +321,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -335,13 +335,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -349,13 +349,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -363,13 +363,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -377,13 +377,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -391,13 +391,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -405,13 +405,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -419,13 +419,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -433,13 +433,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -447,13 +447,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -461,13 +461,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -475,13 +475,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -489,13 +489,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -503,13 +503,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -517,13 +517,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -531,13 +531,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -545,13 +545,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -559,13 +559,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -573,13 +573,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -587,13 +587,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -601,13 +601,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -615,13 +615,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -629,13 +629,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -643,13 +643,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -657,13 +657,13 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (identifier)
+            function: (identifier)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -671,17 +671,17 @@ end architecture DataFlow;
                     (identifier))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type)))))
       (concurrent_block
         (component_instantiation_statement
           (label_declaration
             (label))
           (instantiated_unit
-            (library_namespace)
-            (name
+            library: (library_namespace)
+            entity: (name
               (identifier)))
           (port_map_aspect
             (association_list
@@ -779,7 +779,7 @@ end architecture DataFlow;
               (identifier_list
                 (identifier))
               (subtype_indication
-                (name
+                type: (name
                   (library_type)))
               (initialiser
                 (variable_assignment)
@@ -790,7 +790,7 @@ end architecture DataFlow;
               (identifier_list
                 (identifier))
               (subtype_indication
-                (name
+                type: (name
                   (library_type)))
               (initialiser
                 (variable_assignment)
@@ -808,14 +808,13 @@ end architecture DataFlow;
                           (simple_expression
                             (name
                               (library_function)
-                              (name_selector
-                                (parenthesis_group
-                                  (association_or_range_list
-                                    (association_element
-                                      (conditional_expression
-                                        (simple_expression
-                                          (name
-                                            (identifier)))))))))))))))
+                              (parenthesis_group
+                                (association_or_range_list
+                                  (association_element
+                                    (conditional_expression
+                                      (simple_expression
+                                        (name
+                                          (identifier))))))))))))))
                 (if_statement_body
                   (simple_waveform_assignment
                     (name
@@ -856,20 +855,17 @@ end architecture DataFlow;
                               (simple_expression
                                 (name
                                   (identifier)
-                                  (name_selector
-                                    (selection
-                                      (identifier)))
-                                  (name_selector
-                                    (selection
-                                      (identifier)))
-                                  (name_selector
-                                    (parenthesis_group
-                                      (association_or_range_list
-                                        (association_element
-                                          (conditional_expression
-                                            (simple_expression
-                                              (name
-                                                (identifier))))))))))))))))
+                                  (selection
+                                    (identifier))
+                                  (selection
+                                    (identifier))
+                                  (parenthesis_group
+                                    (association_or_range_list
+                                      (association_element
+                                        (conditional_expression
+                                          (simple_expression
+                                            (name
+                                              (identifier)))))))))))))))
                   (case_body
                     (case_statement_alternative
                       (when_element
@@ -878,18 +874,17 @@ end architecture DataFlow;
                       (simple_waveform_assignment
                         (name
                           (identifier)
-                          (name_selector
-                            (parenthesis_group
-                              (association_or_range_list
-                                (association_element
-                                  (conditional_expression
+                          (parenthesis_group
+                            (association_or_range_list
+                              (association_element
+                                (conditional_expression
+                                  (simple_expression
                                     (simple_expression
-                                      (simple_expression
-                                        (name
-                                          (identifier)))
-                                      (adding_operator)
-                                      (simple_expression
-                                        (decimal_integer)))))))))
+                                      (name
+                                        (identifier)))
+                                    (adding_operator)
+                                    (simple_expression
+                                      (decimal_integer))))))))
                         (signal_assignment)
                         (waveform
                           (waveform_element
@@ -903,18 +898,17 @@ end architecture DataFlow;
                       (simple_waveform_assignment
                         (name
                           (identifier)
-                          (name_selector
-                            (parenthesis_group
-                              (association_or_range_list
-                                (association_element
-                                  (conditional_expression
+                          (parenthesis_group
+                            (association_or_range_list
+                              (association_element
+                                (conditional_expression
+                                  (simple_expression
                                     (simple_expression
-                                      (simple_expression
-                                        (name
-                                          (identifier)))
-                                      (adding_operator)
-                                      (simple_expression
-                                        (decimal_integer)))))))))
+                                      (name
+                                        (identifier)))
+                                    (adding_operator)
+                                    (simple_expression
+                                      (decimal_integer))))))))
                         (signal_assignment)
                         (waveform
                           (waveform_element
@@ -927,32 +921,30 @@ end architecture DataFlow;
                       (simple_waveform_assignment
                         (name
                           (identifier)
-                          (name_selector
-                            (parenthesis_group
-                              (association_or_range_list
-                                (association_element
-                                  (conditional_expression
+                          (parenthesis_group
+                            (association_or_range_list
+                              (association_element
+                                (conditional_expression
+                                  (simple_expression
                                     (simple_expression
-                                      (simple_expression
-                                        (name
-                                          (identifier)))
-                                      (adding_operator)
-                                      (simple_expression
-                                        (decimal_integer)))))))))
+                                      (name
+                                        (identifier)))
+                                    (adding_operator)
+                                    (simple_expression
+                                      (decimal_integer))))))))
                         (signal_assignment)
                         (waveform
                           (waveform_element
                             (simple_expression
                               (name
                                 (identifier)
-                                (name_selector
-                                  (parenthesis_group
-                                    (association_or_range_list
-                                      (association_element
-                                        (conditional_expression
-                                          (simple_expression
-                                            (name
-                                              (identifier)))))))))))))))
+                                (parenthesis_group
+                                  (association_or_range_list
+                                    (association_element
+                                      (conditional_expression
+                                        (simple_expression
+                                          (name
+                                            (identifier))))))))))))))
                   (end_case)))
               (end_loop)))
           (end_process))
@@ -973,5 +965,5 @@ end architecture DataFlow;
                             (name
                               (identifier)))))))))))))
       (end_architecture
-        (identifier)))))
+        architecture: (identifier)))))
 

--- a/test/corpus/specification_examples/architecture.vhd
+++ b/test/corpus/specification_examples/architecture.vhd
@@ -96,55 +96,42 @@ end architecture DataFlow;
 (design_file
   (design_unit
     (library_clause
-      (LIBRARY)
       (logical_name_list
         (library_namespace))))
   (design_unit
     (use_clause
-      (USE)
       (selected_name
         (library_namespace)
-        (identifier)
-        (ALL))))
+        (identifier))))
   (design_unit
     (library_clause
-      (LIBRARY)
       (logical_name_list
         (library_namespace))))
   (design_unit
     (use_clause
-      (USE)
       (selected_name
         (library_namespace)
-        (identifier)
-        (ALL))))
+        (identifier))))
   (design_unit
     (library_clause
-      (LIBRARY)
       (logical_name_list
         (library_namespace))))
   (design_unit
     (use_clause
-      (USE)
       (selected_name
         (library_namespace)
-        (identifier)
-        (ALL))))
+        (identifier))))
   (design_unit
     (entity_declaration
-      (ENTITY)
       (identifier)
       (entity_head
-        (IS)
         (port_clause
-          (PORT)
           (interface_list
             (interface_declaration
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
@@ -152,28 +139,21 @@ end architecture DataFlow;
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type))))))))
       (end_entity
-        (END)
-        (ENTITY)
         (identifier))))
   (line_comment
     (comment_content))
   (design_unit
     (architecture_definition
-      (ARCHITECTURE)
       (identifier)
-      (OF)
       (name
         (identifier))
       (architecture_head
-        (IS)
         (signal_declaration
-          (SIGNAL)
           (identifier_list
             (identifier)
             (identifier))
@@ -182,7 +162,6 @@ end architecture DataFlow;
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -193,12 +172,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -209,12 +186,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -225,12 +200,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -241,12 +214,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -257,12 +228,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -273,12 +242,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -289,12 +256,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -305,12 +270,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -321,12 +284,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -337,12 +298,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -353,12 +312,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -369,12 +326,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -385,12 +340,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -401,12 +354,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -417,12 +368,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -433,12 +382,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -449,12 +396,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -465,12 +410,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -481,12 +424,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -497,12 +438,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -513,12 +452,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -529,12 +466,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -545,12 +480,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -561,12 +494,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -577,12 +508,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -593,12 +522,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -609,12 +536,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -625,12 +550,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -641,12 +564,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -657,12 +578,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -673,12 +592,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -689,12 +606,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -705,12 +620,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -721,12 +634,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -737,12 +648,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -753,12 +662,10 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type))))
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (identifier)
             (parameter_list_specification
               (interface_list
@@ -769,22 +676,17 @@ end architecture DataFlow;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type)))))
       (concurrent_block
-        (BEGIN)
         (component_instantiation_statement
           (label_declaration
             (label))
           (instantiated_unit
-            (ENTITY)
             (library_namespace)
             (name
               (identifier)))
           (port_map_aspect
-            (PORT)
-            (MAP)
             (association_list
               (association_element
                 (name
@@ -867,7 +769,6 @@ end architecture DataFlow;
                               (name
                                 (identifier)))))))))))))
         (process_statement
-          (PROCESS)
           (sensitivity_specification
             (sensitivity_list
               (name
@@ -877,9 +778,7 @@ end architecture DataFlow;
               (name
                 (identifier))))
           (process_head
-            (IS)
             (constant_declaration
-              (CONSTANT)
               (identifier_list
                 (identifier))
               (subtype_indication
@@ -891,7 +790,6 @@ end architecture DataFlow;
                   (simple_expression
                     (decimal_float)))))
             (variable_declaration
-              (VARIABLE)
               (identifier_list
                 (identifier))
               (subtype_indication
@@ -903,10 +801,8 @@ end architecture DataFlow;
                   (simple_expression
                     (decimal_integer))))))
           (sequential_block
-            (BEGIN)
             (if_statement_block
               (if_statement
-                (IF)
                 (simple_expression
                   (parenthesis_expression
                     (element_association_list
@@ -923,7 +819,6 @@ end architecture DataFlow;
                                         (simple_expression
                                           (name
                                             (identifier)))))))))))))))
-                (THEN)
                 (if_statement_body
                   (simple_waveform_assignment
                     (name
@@ -934,7 +829,6 @@ end architecture DataFlow;
                         (simple_expression
                           (decimal_integer)))))))
               (else_statement
-                (ELSE)
                 (if_statement_body
                   (simple_waveform_assignment
                     (name
@@ -944,26 +838,19 @@ end architecture DataFlow;
                       (waveform_element
                         (simple_expression
                           (decimal_integer)))))))
-              (end_if
-                (END)
-                (IF)))
+              (end_if))
             (loop_statement
               (for_loop
-                (FOR)
                 (parameter_specification
                   (identifier)
-                  (IN)
                   (simple_range
                     (simple_expression
                       (decimal_integer))
-                    (TO)
                     (simple_expression
                       (decimal_integer)))))
               (loop_body
-                (LOOP)
                 (case_statement
                   (case_expression
-                    (CASE)
                     (simple_expression
                       (parenthesis_expression
                         (element_association_list
@@ -987,10 +874,8 @@ end architecture DataFlow;
                                               (name
                                                 (identifier))))))))))))))))
                   (case_body
-                    (IS)
                     (case_statement_alternative
                       (when_element
-                        (WHEN)
                         (simple_expression
                           (string_literal_std_logic)))
                       (simple_waveform_assignment
@@ -1016,7 +901,6 @@ end architecture DataFlow;
                                 (library_constant_std_logic)))))))
                     (case_statement_alternative
                       (when_element
-                        (WHEN)
                         (simple_expression
                           (string_literal_std_logic)))
                       (simple_waveform_assignment
@@ -1041,9 +925,7 @@ end architecture DataFlow;
                               (name
                                 (library_constant_std_logic)))))))
                     (case_statement_alternative
-                      (when_element
-                        (WHEN)
-                        (OTHERS))
+                      (when_element)
                       (simple_waveform_assignment
                         (name
                           (identifier)
@@ -1073,15 +955,9 @@ end architecture DataFlow;
                                           (simple_expression
                                             (name
                                               (identifier)))))))))))))))
-                  (end_case
-                    (END)
-                    (CASE))))
-              (end_loop
-                (END)
-                (LOOP))))
-          (end_process
-            (END)
-            (PROCESS)))
+                  (end_case)))
+              (end_loop)))
+          (end_process))
         (concurrent_simple_signal_assignment
           (name
             (identifier))
@@ -1099,8 +975,5 @@ end architecture DataFlow;
                             (name
                               (identifier)))))))))))))
       (end_architecture
-        (END)
-        (ARCHITECTURE)
         (identifier)))))
-
 

--- a/test/corpus/specification_examples/configuration.vhd
+++ b/test/corpus/specification_examples/configuration.vhd
@@ -1,0 +1,81 @@
+================================================================================
+Configuration
+================================================================================
+
+library TTL, Work;
+
+configuration V4_27_87 of Processor is
+  use Work.all;
+  for Structure_View
+    for A1: ALU
+      use configuration TTL.SN74LS181;
+    end for;
+    for M1,M2,M3: MUX
+      use entity Multiplex4 (Behavior);
+    end for;
+    for all: Latch
+      -- use defaults
+    end for;
+  end for;
+end configuration V4_27_87;
+
+--------------------------------------------------------------------------------
+
+(design_file
+  (design_unit
+    (library_clause
+      (logical_name_list
+        library: (identifier)
+        library: (library_namespace)))
+    (configuration_declaration
+      configuration: (identifier)
+      entity: (name
+        (identifier))
+      (configuration_head
+        (use_clause
+          (selected_name
+            library: (library_namespace)
+            (ALL))))
+      (block_configuration
+        (name
+          (identifier))
+        (component_configuration
+          (component_specification
+            (instantiation_list
+              (label))
+            (name
+              (identifier)))
+          (binding_indication
+            (entity_aspect
+              configuration: (name
+                (identifier)
+                (selection
+                  (identifier)))))
+          (end_for))
+        (component_configuration
+          (component_specification
+            (instantiation_list
+              (label)
+              (label)
+              (label))
+            (name
+              (identifier)))
+          (binding_indication
+            (entity_aspect
+              entity: (name
+                (identifier))
+              architecture: (identifier)))
+          (end_for))
+        (component_configuration
+          (component_specification
+            (instantiation_list
+              (ALL))
+            (name
+              (identifier)))
+          (line_comment
+            (comment_content))
+          (end_for))
+        (end_for))
+      (end_configuration
+        configuration: (identifier)))))
+

--- a/test/corpus/specification_examples/entity.vhd
+++ b/test/corpus/specification_examples/entity.vhd
@@ -11,7 +11,7 @@ end Full_Adder;
 (design_file
   (design_unit
     (entity_declaration
-      (identifier)
+      entity: (identifier)
       (entity_head
         (port_clause
           (interface_list
@@ -23,7 +23,7 @@ end Full_Adder;
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (interface_declaration
               (identifier_list
@@ -32,10 +32,10 @@ end Full_Adder;
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type))))))))
       (end_entity
-        (identifier)))))
+        entity: (identifier)))))
 
 ================================================================================
 An entity declaration with generic declarations also:
@@ -52,7 +52,7 @@ end entity AndGate;
 (design_file
   (design_unit
     (entity_declaration
-      (identifier)
+      entity: (identifier)
       (entity_head
         (generic_clause
           (interface_list
@@ -61,7 +61,7 @@ end entity AndGate;
                 (identifier))
               (simple_mode_indication
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))
                 (initialiser
                   (variable_assignment)
@@ -76,27 +76,26 @@ end entity AndGate;
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)
-                    (name_selector
-                      (parenthesis_group
-                        (association_or_range_list
-                          (simple_range
-                            (simple_expression
-                              (decimal_integer))
-                            (simple_expression
-                              (name
-                                (identifier)))))))))))
+                    (parenthesis_group
+                      (association_or_range_list
+                        (simple_range
+                          (simple_expression
+                            (decimal_integer))
+                          (simple_expression
+                            (name
+                              (identifier))))))))))
             (interface_declaration
               (identifier_list
                 (identifier))
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type))))))))
       (end_entity
-        (identifier)))))
+        entity: (identifier)))))
 
 ================================================================================
 An entity declaration with neither:
@@ -110,10 +109,10 @@ end TestBench;
 (design_file
   (design_unit
     (entity_declaration
-      (identifier)
+      entity: (identifier)
       (entity_head)
       (end_entity
-        (identifier)))))
+        entity: (identifier)))))
 
 ================================================================================
 An entity declaration with entity declarative items:
@@ -140,7 +139,7 @@ end ROM;
 (design_file
   (design_unit
     (entity_declaration
-      (identifier)
+      entity: (identifier)
       (entity_head
         (port_clause
           (interface_list
@@ -150,7 +149,7 @@ end ROM;
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (identifier)))))
             (interface_declaration
               (identifier_list
@@ -158,7 +157,7 @@ end ROM;
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (identifier)))))
             (interface_declaration
               (identifier_list
@@ -166,10 +165,10 @@ end ROM;
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))))
         (type_declaration
-          (identifier)
+          type: (identifier)
           (array_type_definition
             (array_index_incomplete_type_list
               (index_constraint
@@ -179,32 +178,32 @@ end ROM;
                   (simple_expression
                     (decimal_integer)))))
             (subtype_indication
-              (name
+              type: (name
                 (library_type)))))
         (type_declaration
-          (identifier)
+          type: (identifier)
           (array_type_definition
             (array_index_incomplete_type_list
               (index_subtype_definition
-                (name
+                type: (name
                   (library_type))))
             (subtype_indication
-              (name
+              type: (name
                 (identifier)))))
         (use_clause
           (selected_name
-            (library_namespace)
+            library: (library_namespace)
             (identifier)
             (ALL))
           (selected_name
-            (library_namespace)
+            library: (library_namespace)
             (identifier)
             (ALL)))
         (constant_declaration
           (identifier_list
             (identifier))
           (subtype_indication
-            (name
+            type: (name
               (identifier)))
           (initialiser
             (variable_assignment)
@@ -300,7 +299,7 @@ end ROM;
                   (line_comment
                     (comment_content))))))))
       (end_entity
-        (identifier)))))
+        entity: (identifier)))))
 
 ================================================================================
 An entity declaration with statements:
@@ -324,7 +323,7 @@ end;
 (design_file
   (design_unit
     (entity_declaration
-      (identifier)
+      entity: (identifier)
       (entity_head
         (port_clause
           (interface_list
@@ -334,7 +333,7 @@ end;
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (identifier)))))
             (interface_declaration
               (identifier_list
@@ -342,7 +341,7 @@ end;
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (identifier)))))
             (interface_declaration
               (identifier_list
@@ -350,7 +349,7 @@ end;
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))
             (interface_declaration
               (identifier_list
@@ -358,35 +357,35 @@ end;
               (simple_mode_indication
                 (mode)
                 (subtype_indication
-                  (name
+                  type: (name
                     (library_type)))))))
         (constant_declaration
           (identifier_list
             (identifier))
           (subtype_indication
-            (name
+            type: (name
               (library_type)))
           (initialiser
             (variable_assignment)
             (conditional_expression
               (simple_expression
                 (decimal_integer)
-                (library_constant_unit)))))
+                unit: (library_constant_unit)))))
         (constant_declaration
           (identifier_list
             (identifier))
           (subtype_indication
-            (name
+            type: (name
               (library_type)))
           (initialiser
             (variable_assignment)
             (conditional_expression
               (simple_expression
                 (decimal_integer)
-                (library_constant_unit)))))
+                unit: (library_constant_unit)))))
         (use_clause
           (selected_name
-            (library_namespace)
+            library: (library_namespace)
             (identifier)
             (ALL))))
       (entity_body
@@ -405,44 +404,40 @@ end;
               (simple_expression
                 (name
                   (identifier)
-                  (name_selector
-                    (attribute
-                      (attribute_signal)))
-                  (name_selector
-                    (attribute
-                      (attribute_signal)))
-                  (name_selector
-                    (parenthesis_group
-                      (association_or_range_list
-                        (association_element
-                          (conditional_expression
-                            (simple_expression
-                              (name
-                                (identifier)))))))))))))
+                  (attribute
+                    attribute: (attribute_signal))
+                  (attribute
+                    attribute: (attribute_signal))
+                  (parenthesis_group
+                    (association_or_range_list
+                      (association_element
+                        (conditional_expression
+                          (simple_expression
+                            (name
+                              (identifier))))))))))))
         (concurrent_procedure_call_statement
           (name
             (identifier)
-            (name_selector
-              (parenthesis_group
-                (association_or_range_list
-                  (association_element
-                    (conditional_expression
-                      (simple_expression
-                        (name
-                          (identifier)))))
-                  (association_element
-                    (conditional_expression
-                      (simple_expression
-                        (name
-                          (identifier)))))
-                  (association_element
-                    (conditional_expression
-                      (simple_expression
-                        (name
-                          (identifier)))))
-                  (association_element
-                    (conditional_expression
-                      (simple_expression
-                        (name
-                          (identifier)))))))))))
+            (parenthesis_group
+              (association_or_range_list
+                (association_element
+                  (conditional_expression
+                    (simple_expression
+                      (name
+                        (identifier)))))
+                (association_element
+                  (conditional_expression
+                    (simple_expression
+                      (name
+                        (identifier)))))
+                (association_element
+                  (conditional_expression
+                    (simple_expression
+                      (name
+                        (identifier)))))
+                (association_element
+                  (conditional_expression
+                    (simple_expression
+                      (name
+                        (identifier))))))))))
       (end_entity))))

--- a/test/corpus/specification_examples/entity.vhd
+++ b/test/corpus/specification_examples/entity.vhd
@@ -11,12 +11,9 @@ end Full_Adder;
 (design_file
   (design_unit
     (entity_declaration
-      (ENTITY)
       (identifier)
       (entity_head
-        (IS)
         (port_clause
-          (PORT)
           (interface_list
             (interface_declaration
               (identifier_list
@@ -24,8 +21,7 @@ end Full_Adder;
                 (identifier)
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
@@ -34,13 +30,11 @@ end Full_Adder;
                 (identifier)
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (OUT))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type))))))))
       (end_entity
-        (END)
         (identifier)))))
 
 ================================================================================
@@ -58,12 +52,9 @@ end entity AndGate;
 (design_file
   (design_unit
     (entity_declaration
-      (ENTITY)
       (identifier)
       (entity_head
-        (IS)
         (generic_clause
-          (GENERIC)
           (interface_list
             (interface_declaration
               (identifier_list
@@ -78,14 +69,12 @@ end entity AndGate;
                     (simple_expression
                       (decimal_integer))))))))
         (port_clause
-          (PORT)
           (interface_list
             (interface_declaration
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)
@@ -95,7 +84,6 @@ end entity AndGate;
                           (simple_range
                             (simple_expression
                               (decimal_integer))
-                            (TO)
                             (simple_expression
                               (name
                                 (identifier)))))))))))
@@ -103,14 +91,11 @@ end entity AndGate;
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (OUT))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type))))))))
       (end_entity
-        (END)
-        (ENTITY)
         (identifier)))))
 
 ================================================================================
@@ -125,12 +110,9 @@ end TestBench;
 (design_file
   (design_unit
     (entity_declaration
-      (ENTITY)
       (identifier)
-      (entity_head
-        (IS))
+      (entity_head)
       (end_entity
-        (END)
         (identifier)))))
 
 ================================================================================
@@ -158,19 +140,15 @@ end ROM;
 (design_file
   (design_unit
     (entity_declaration
-      (ENTITY)
       (identifier)
       (entity_head
-        (IS)
         (port_clause
-          (PORT)
           (interface_list
             (interface_declaration
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (identifier)))))
@@ -178,8 +156,7 @@ end ROM;
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (OUT))
+                (mode)
                 (subtype_indication
                   (name
                     (identifier)))))
@@ -187,57 +164,41 @@ end ROM;
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))))
         (type_declaration
-          (TYPE)
           (identifier)
-          (IS)
           (array_type_definition
-            (ARRAY)
             (array_index_incomplete_type_list
               (index_constraint
                 (simple_range
                   (simple_expression
                     (decimal_integer))
-                  (TO)
                   (simple_expression
                     (decimal_integer)))))
-            (OF)
             (subtype_indication
               (name
                 (library_type)))))
         (type_declaration
-          (TYPE)
           (identifier)
-          (IS)
           (array_type_definition
-            (ARRAY)
             (array_index_incomplete_type_list
               (index_subtype_definition
                 (name
-                  (library_type))
-                (RANGE)
-                (box)))
-            (OF)
+                  (library_type))))
             (subtype_indication
               (name
                 (identifier)))))
         (use_clause
-          (USE)
           (selected_name
             (library_namespace)
-            (identifier)
-            (ALL))
+            (identifier))
           (selected_name
             (library_namespace)
-            (identifier)
-            (ALL)))
+            (identifier)))
         (constant_declaration
-          (CONSTANT)
           (identifier_list
             (identifier))
           (subtype_indication
@@ -337,7 +298,6 @@ end ROM;
                   (line_comment
                     (comment_content))))))))
       (end_entity
-        (END)
         (identifier)))))
 
 ================================================================================
@@ -362,19 +322,15 @@ end;
 (design_file
   (design_unit
     (entity_declaration
-      (ENTITY)
       (identifier)
       (entity_head
-        (IS)
         (port_clause
-          (PORT)
           (interface_list
             (interface_declaration
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (identifier)))))
@@ -382,8 +338,7 @@ end;
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (OUT))
+                (mode)
                 (subtype_indication
                   (name
                     (identifier)))))
@@ -391,8 +346,7 @@ end;
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))
@@ -400,13 +354,11 @@ end;
               (identifier_list
                 (identifier))
               (simple_mode_indication
-                (mode
-                  (IN))
+                (mode)
                 (subtype_indication
                   (name
                     (library_type)))))))
         (constant_declaration
-          (CONSTANT)
           (identifier_list
             (identifier))
           (subtype_indication
@@ -419,7 +371,6 @@ end;
                 (decimal_integer)
                 (library_constant_unit)))))
         (constant_declaration
-          (CONSTANT)
           (identifier_list
             (identifier))
           (subtype_indication
@@ -432,16 +383,12 @@ end;
                 (decimal_integer)
                 (library_constant_unit)))))
         (use_clause
-          (USE)
           (selected_name
             (library_namespace)
-            (identifier)
-            (ALL))))
+            (identifier))))
       (entity_body
-        (BEGIN)
         (concurrent_assertion_statement
           (assertion
-            (ASSERT)
             (logical_expression
               (relational_expression
                 (simple_expression
@@ -495,5 +442,4 @@ end;
                       (simple_expression
                         (name
                           (identifier)))))))))))
-      (end_entity
-        (END)))))
+      (end_entity))))

--- a/test/corpus/specification_examples/entity.vhd
+++ b/test/corpus/specification_examples/entity.vhd
@@ -194,10 +194,12 @@ end ROM;
         (use_clause
           (selected_name
             (library_namespace)
-            (identifier))
+            (identifier)
+            (ALL))
           (selected_name
             (library_namespace)
-            (identifier)))
+            (identifier)
+            (ALL)))
         (constant_declaration
           (identifier_list
             (identifier))
@@ -385,7 +387,8 @@ end;
         (use_clause
           (selected_name
             (library_namespace)
-            (identifier))))
+            (identifier)
+            (ALL))))
       (entity_body
         (concurrent_assertion_statement
           (assertion

--- a/test/corpus/string_literal_std_logic.vhd
+++ b/test/corpus/string_literal_std_logic.vhd
@@ -26,13 +26,13 @@ end Behaviour;
 (design_file
   (design_unit
     (architecture_definition
-      (identifier)
-      (name
+      architecture: (identifier)
+      entity: (name
         (identifier))
       (architecture_head
         (subprogram_declaration
           (function_specification
-            (operator_symbol)
+            function: (operator_symbol)
             (parameter_list_specification
               (interface_list
                 (interface_declaration
@@ -41,9 +41,9 @@ end Behaviour;
                     (library_constant))
                   (simple_mode_indication
                     (subtype_indication
-                      (name
+                      type: (name
                         (library_type)))))))
-            (name
+            type: (name
               (library_type)))))
       (concurrent_block
         (concurrent_simple_signal_assignment
@@ -179,5 +179,5 @@ end Behaviour;
       (line_comment
         (comment_content))
       (end_architecture
-        (identifier)))))
+        architecture: (identifier)))))
 

--- a/test/corpus/string_literal_std_logic.vhd
+++ b/test/corpus/string_literal_std_logic.vhd
@@ -26,16 +26,12 @@ end Behaviour;
 (design_file
   (design_unit
     (architecture_definition
-      (ARCHITECTURE)
       (identifier)
-      (OF)
       (name
         (identifier))
       (architecture_head
-        (IS)
         (subprogram_declaration
           (function_specification
-            (FUNCTION)
             (operator_symbol)
             (parameter_list_specification
               (interface_list
@@ -47,11 +43,9 @@ end Behaviour;
                     (subtype_indication
                       (name
                         (library_type)))))))
-            (RETURN)
             (name
               (library_type)))))
       (concurrent_block
-        (BEGIN)
         (concurrent_simple_signal_assignment
           (name
             (identifier))
@@ -185,6 +179,5 @@ end Behaviour;
       (line_comment
         (comment_content))
       (end_architecture
-        (END)
         (identifier)))))
 

--- a/test/corpus/tool_directives.vhd
+++ b/test/corpus/tool_directives.vhd
@@ -19,32 +19,23 @@ end process;
 (design_file
   (design_unit
     (process_statement
-      (PROCESS)
-      (sensitivity_specification
-        (ALL))
+      (sensitivity_specification)
       (sequential_block
-        (BEGIN)
         (if_conditional_analysis
-          (IF)
           (conditional_analysis_expression
             (conditional_analysis_relation
               (identifier)
-              (string_literal)))
-          (THEN))
+              (string_literal))))
         (loop_statement
           (for_loop
-            (FOR)
             (parameter_specification
               (identifier)
-              (IN)
               (simple_range
                 (simple_expression
                   (decimal_integer))
-                (TO)
                 (simple_expression
                   (decimal_integer)))))
           (loop_body
-            (LOOP)
             (simple_variable_assignment
               (name
                 (identifier))
@@ -66,25 +57,18 @@ end process;
                                 (simple_expression
                                   (name
                                     (identifier))))))))))))))
-          (end_loop
-            (END)
-            (LOOP)))
-        (else_conditional_analysis
-          (ELSE))
+          (end_loop))
+        (else_conditional_analysis)
         (loop_statement
           (for_loop
-            (FOR)
             (parameter_specification
               (identifier)
-              (IN)
               (simple_range
                 (simple_expression
                   (decimal_integer))
-                (TO)
                 (simple_expression
                   (decimal_integer)))))
           (loop_body
-            (LOOP)
             (simple_variable_assignment
               (name
                 (identifier))
@@ -106,13 +90,7 @@ end process;
                                 (simple_expression
                                   (name
                                     (identifier))))))))))))))
-          (end_loop
-            (END)
-            (LOOP))))
-      (end_conditional_analysis
-        (END)
-        (IF))
-      (end_process
-        (END)
-        (PROCESS)))))
+          (end_loop)))
+      (end_conditional_analysis)
+      (end_process))))
 

--- a/test/corpus/tool_directives.vhd
+++ b/test/corpus/tool_directives.vhd
@@ -50,14 +50,13 @@ end process;
                   (simple_expression
                     (name
                       (identifier)
-                      (name_selector
-                        (parenthesis_group
-                          (association_or_range_list
-                            (association_element
-                              (conditional_expression
-                                (simple_expression
-                                  (name
-                                    (identifier))))))))))))))
+                      (parenthesis_group
+                        (association_or_range_list
+                          (association_element
+                            (conditional_expression
+                              (simple_expression
+                                (name
+                                  (identifier)))))))))))))
           (end_loop))
         (else_conditional_analysis)
         (loop_statement
@@ -83,14 +82,13 @@ end process;
                   (simple_expression
                     (name
                       (identifier)
-                      (name_selector
-                        (parenthesis_group
-                          (association_or_range_list
-                            (association_element
-                              (conditional_expression
-                                (simple_expression
-                                  (name
-                                    (identifier))))))))))))))
+                      (parenthesis_group
+                        (association_or_range_list
+                          (association_element
+                            (conditional_expression
+                              (simple_expression
+                                (name
+                                  (identifier)))))))))))))
           (end_loop)))
       (end_conditional_analysis)
       (end_process))))

--- a/test/corpus/tool_directives.vhd
+++ b/test/corpus/tool_directives.vhd
@@ -19,7 +19,8 @@ end process;
 (design_file
   (design_unit
     (process_statement
-      (sensitivity_specification)
+      (sensitivity_specification
+        (ALL))
       (sequential_block
         (if_conditional_analysis
           (conditional_analysis_expression

--- a/test/highlight/architecture_basic.vhd
+++ b/test/highlight/architecture_basic.vhd
@@ -4,16 +4,16 @@ architecture EXAMPLE of STRUCTURE is
 --                   ^ keyword.operator
 --                      ^ module
 --                                ^ keyword
-  subtype  DIGIT is integer range 0 to 9;
+  subtype DIGIT is integer range 0 to 9;
 -- ^ keyword.type
---         ^ variable
---               ^ keyword
---                  ^ type.builtin
---                          ^ keyword
---                                ^ number
---                                  ^ keyword.operator
---                                     ^ number
---                                      ^ punctuation.delimiters
+--        ^ type.definition
+--              ^ keyword
+--                 ^ type.builtin
+--                         ^ keyword
+--                               ^ number
+--                                 ^ keyword.operator
+--                                    ^ number
+--                                     ^ punctuation.delimiters
 begin
 -- ^ keyword
   DIGIT_A <= 3;


### PR DESCRIPTION
@Chris44442, @superzanti,

I got annoyed with all the keywords that are explicit in the syntax tree, so I changed them all to anonymous nodes (i.e. strings, like the operators are at the moment).

But I need a second opinion...  Is this a good idea?  Should I merge this?  Are there keywords (like `all`, for example, that are better left explicit?