### PR TITLE
Fixed the generate block

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -757,16 +757,12 @@ module.exports = grammar({
             ),
 
             generate_body: $ => choice(
-                $.generate_direct_block,
-                seq($.generate_head, $.generate_block, optional($.generate_block_end))
+                seq(alias($.GENERATE, "generate"), optional($.generate_block)),
+                seq(alias($.GENERATE, "generate"), optional($.generate_head), alias($.BEGIN, "begin"), optional($.generate_block), optional($.generate_block_end))
             ),
 
             generate_head: $ => seq(
-                alias($.GENERATE, "generate"), repeat($._block_declarative_item)
-            ),
-
-            generate_direct_block: $ => seq(
-                alias($.GENERATE, "generate"), repeat($._concurrent_statement)
+                repeat1($._block_declarative_item)
             ),
 
             case_generate_alternative: $ => prec.left(seq(
@@ -774,20 +770,12 @@ module.exports = grammar({
             )),
 
             case_generate_body: $ => choice(
-                $.case_generate_direct_block,
-                seq($.case_generate_head, $.generate_block, optional($.generate_block_end))
-            ),
-
-            case_generate_head: $ => seq(
-                "=>", repeat($._block_declarative_item)
-            ),
-
-            case_generate_direct_block: $ => seq(
-                "=>", repeat($._concurrent_statement)
+                seq("=>", optional($.generate_block)),
+                seq("=>", optional($.generate_head), alias($.BEGIN, "begin"), optional($.generate_block), optional($.generate_block_end))
             ),
 
             generate_block: $ => seq(
-                alias($.BEGIN, "begin"), repeat($._concurrent_statement)
+                repeat1($._concurrent_statement)
             ),
 
             generate_block_end: $ => seq(
@@ -898,11 +886,11 @@ module.exports = grammar({
             ),
 
             case_generate_statement: $ => seq(
-                $.label_declaration, alias($.CASE, "case"), $._expression, $.case_generate_block, $.end_generate, ";"
+                $.label_declaration, alias($.CASE, "case"), $._expression, alias($.GENERATE, "generate"), $.case_generate_block, $.end_generate, ";"
             ),
 
             case_generate_block: $ => seq(
-                alias($.GENERATE, "generate"), repeat1($.case_generate_alternative)
+                repeat1($.case_generate_alternative)
             ),
 
             for_generate_statement: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -199,7 +199,10 @@ module.exports = grammar({
         /\s+/
     ],
 
-    conflicts: $ => [ ],
+    conflicts: $ => [
+        [ $.generate_body ],
+        [ $.case_generate_body ]
+    ],
 
     rules: {
         // Design File
@@ -755,7 +758,7 @@ module.exports = grammar({
 
             generate_body: $ => choice(
                 $.generate_direct_block,
-                seq($.generate_head, $.generate_block, $.generate_block_end)
+                seq($.generate_head, $.generate_block, optional($.generate_block_end))
             ),
 
             generate_head: $ => seq(
@@ -772,7 +775,7 @@ module.exports = grammar({
 
             case_generate_body: $ => choice(
                 $.case_generate_direct_block,
-                seq($.case_generate_head, $.generate_block, $.generate_block_end)
+                seq($.case_generate_head, $.generate_block, optional($.generate_block_end))
             ),
 
             case_generate_head: $ => seq(

--- a/queries/Neovim/textobjects.scm
+++ b/queries/Neovim/textobjects.scm
@@ -179,8 +179,8 @@
 (if_generate_statement
   (if_generate
     (generate_body
-      (generate_direct_block
-        "generate"
+      "generate"
+      (generate_block
         .
         (_) @_start @_end
         (_)? @_end .)))
@@ -191,8 +191,8 @@
 
 (if_generate
   (generate_body
-    (generate_direct_block
-      "generate"
+    "generate"
+    (generate_block
       .
       (_) @_start @_end
       (_)? @_end
@@ -201,8 +201,8 @@
 
 (elsif_generate
   (generate_body
-    (generate_direct_block
-      "generate"
+    "generate"
+    (generate_block
       .
       (_) @_start @_end
       (_)? @_end
@@ -211,8 +211,8 @@
 
 (else_generate
   (generate_body
-    (generate_direct_block
-      "generate"
+    "generate"
+    (generate_block
       .
       (_) @_start @_end
       (_)? @_end
@@ -221,8 +221,8 @@
 
 (for_generate_statement
   (generate_body
-    (generate_direct_block
-      "generate"
+    "generate"
+    (generate_block
       .
       (_) @_start @_end
       (_)? @_end
@@ -230,8 +230,8 @@
       (#make-range! "block.inner" @_start @_end)))) @block.outer
 
 (case_generate_statement
+  "generate"
   (case_generate_block
-    "generate"
     .
     (_) @_start @_end
     (_)? @_end
@@ -240,8 +240,8 @@
 
 (case_generate_alternative
   (case_generate_body
-    (case_generate_direct_block
-      "=>"
+    "=>"
+    (generate_block
       .
       (_) @_start @_end
       (_)? @_end

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3660,8 +3660,16 @@
               "name": "generate_block"
             },
             {
-              "type": "SYMBOL",
-              "name": "generate_block_end"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "generate_block_end"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         }
@@ -3766,8 +3774,16 @@
               "name": "generate_block"
             },
             {
-              "type": "SYMBOL",
-              "name": "generate_block_end"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "generate_block_end"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         }
@@ -12448,7 +12464,14 @@
       "value": "\\s+"
     }
   ],
-  "conflicts": [],
+  "conflicts": [
+    [
+      "generate_body"
+    ],
+    [
+      "case_generate_body"
+    ]
+  ],
   "precedences": [],
   "externals": [
     {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3645,19 +3645,75 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "generate_direct_block"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "GENERATE"
+              },
+              "named": false,
+              "value": "generate"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "generate_block"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         },
         {
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "generate_head"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "GENERATE"
+              },
+              "named": false,
+              "value": "generate"
             },
             {
-              "type": "SYMBOL",
-              "name": "generate_block"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "generate_head"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "BEGIN"
+              },
+              "named": false,
+              "value": "begin"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "generate_block"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
               "type": "CHOICE",
@@ -3679,40 +3735,10 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "GENERATE"
-          },
-          "named": false,
-          "value": "generate"
-        },
-        {
-          "type": "REPEAT",
+          "type": "REPEAT1",
           "content": {
             "type": "SYMBOL",
             "name": "_block_declarative_item"
-          }
-        }
-      ]
-    },
-    "generate_direct_block": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "GENERATE"
-          },
-          "named": false,
-          "value": "generate"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_concurrent_statement"
           }
         }
       ]
@@ -3759,19 +3785,65 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "case_generate_direct_block"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "=>"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "generate_block"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         },
         {
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "case_generate_head"
+              "type": "STRING",
+              "value": "=>"
             },
             {
-              "type": "SYMBOL",
-              "name": "generate_block"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "generate_head"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "BEGIN"
+              },
+              "named": false,
+              "value": "begin"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "generate_block"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
               "type": "CHOICE",
@@ -3789,52 +3861,11 @@
         }
       ]
     },
-    "case_generate_head": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "=>"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_block_declarative_item"
-          }
-        }
-      ]
-    },
-    "case_generate_direct_block": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "=>"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_concurrent_statement"
-          }
-        }
-      ]
-    },
     "generate_block": {
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "BEGIN"
-          },
-          "named": false,
-          "value": "begin"
-        },
-        {
-          "type": "REPEAT",
+          "type": "REPEAT1",
           "content": {
             "type": "SYMBOL",
             "name": "_concurrent_statement"
@@ -4858,6 +4889,15 @@
           "name": "_expression"
         },
         {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "GENERATE"
+          },
+          "named": false,
+          "value": "generate"
+        },
+        {
           "type": "SYMBOL",
           "name": "case_generate_block"
         },
@@ -4874,15 +4914,6 @@
     "case_generate_block": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "GENERATE"
-          },
-          "named": false,
-          "value": "generate"
-        },
         {
           "type": "REPEAT1",
           "content": {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1049,16 +1049,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "case_generate_direct_block",
-          "named": true
-        },
-        {
-          "type": "case_generate_head",
-          "named": true
-        },
         {
           "type": "generate_block",
           "named": true
@@ -1066,159 +1058,9 @@
         {
           "type": "generate_block_end",
           "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "case_generate_direct_block",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "block_statement",
-          "named": true
         },
         {
-          "type": "case_generate_statement",
-          "named": true
-        },
-        {
-          "type": "component_instantiation_statement",
-          "named": true
-        },
-        {
-          "type": "concurrent_assertion_statement",
-          "named": true
-        },
-        {
-          "type": "concurrent_conditional_signal_assignment",
-          "named": true
-        },
-        {
-          "type": "concurrent_procedure_call_statement",
-          "named": true
-        },
-        {
-          "type": "concurrent_selected_signal_assignment",
-          "named": true
-        },
-        {
-          "type": "concurrent_simple_signal_assignment",
-          "named": true
-        },
-        {
-          "type": "for_generate_statement",
-          "named": true
-        },
-        {
-          "type": "if_generate_statement",
-          "named": true
-        },
-        {
-          "type": "process_statement",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "case_generate_head",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "alias_declaration",
-          "named": true
-        },
-        {
-          "type": "attribute_declaration",
-          "named": true
-        },
-        {
-          "type": "attribute_specification",
-          "named": true
-        },
-        {
-          "type": "component_declaration",
-          "named": true
-        },
-        {
-          "type": "configuration_specification",
-          "named": true
-        },
-        {
-          "type": "constant_declaration",
-          "named": true
-        },
-        {
-          "type": "disconnection_specification",
-          "named": true
-        },
-        {
-          "type": "file_declaration",
-          "named": true
-        },
-        {
-          "type": "group_declaration",
-          "named": true
-        },
-        {
-          "type": "group_template_declaration",
-          "named": true
-        },
-        {
-          "type": "mode_view_declaration",
-          "named": true
-        },
-        {
-          "type": "package_declaration",
-          "named": true
-        },
-        {
-          "type": "package_definition",
-          "named": true
-        },
-        {
-          "type": "package_instantiation_declaration",
-          "named": true
-        },
-        {
-          "type": "signal_declaration",
-          "named": true
-        },
-        {
-          "type": "subprogram_declaration",
-          "named": true
-        },
-        {
-          "type": "subprogram_definition",
-          "named": true
-        },
-        {
-          "type": "subprogram_instantiation_declaration",
-          "named": true
-        },
-        {
-          "type": "subtype_declaration",
-          "named": true
-        },
-        {
-          "type": "type_declaration",
-          "named": true
-        },
-        {
-          "type": "use_clause",
-          "named": true
-        },
-        {
-          "type": "variable_declaration",
+          "type": "generate_head",
           "named": true
         }
       ]
@@ -3992,7 +3834,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "block_statement",
@@ -4062,7 +3904,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "generate_block",
@@ -4073,66 +3915,7 @@
           "named": true
         },
         {
-          "type": "generate_direct_block",
-          "named": true
-        },
-        {
           "type": "generate_head",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "generate_direct_block",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "block_statement",
-          "named": true
-        },
-        {
-          "type": "case_generate_statement",
-          "named": true
-        },
-        {
-          "type": "component_instantiation_statement",
-          "named": true
-        },
-        {
-          "type": "concurrent_assertion_statement",
-          "named": true
-        },
-        {
-          "type": "concurrent_conditional_signal_assignment",
-          "named": true
-        },
-        {
-          "type": "concurrent_procedure_call_statement",
-          "named": true
-        },
-        {
-          "type": "concurrent_selected_signal_assignment",
-          "named": true
-        },
-        {
-          "type": "concurrent_simple_signal_assignment",
-          "named": true
-        },
-        {
-          "type": "for_generate_statement",
-          "named": true
-        },
-        {
-          "type": "if_generate_statement",
-          "named": true
-        },
-        {
-          "type": "process_statement",
           "named": true
         }
       ]
@@ -4144,7 +3927,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_declaration",

--- a/test/corpus/if_generate.vhd
+++ b/test/corpus/if_generate.vhd
@@ -26,7 +26,7 @@ end generate testGenerate;
           (simple_expression
             (decimal_integer)))
         (generate_body
-          (generate_direct_block
+          (generate_block
             (concurrent_simple_signal_assignment
               (name
                 (identifier))
@@ -50,7 +50,7 @@ end generate testGenerate;
           (simple_expression
             (decimal_integer)))
         (generate_body
-          (generate_direct_block
+          (generate_block
             (concurrent_simple_signal_assignment
               (name
                 (identifier))
@@ -67,7 +67,7 @@ end generate testGenerate;
                         (identifier))))))))))
       (else_generate
         (generate_body
-          (generate_direct_block
+          (generate_block
             (concurrent_simple_signal_assignment
               (name
                 (identifier))

--- a/test/corpus/specification_examples/generate.vhd
+++ b/test/corpus/specification_examples/generate.vhd
@@ -106,7 +106,7 @@ end block Gen2;
                 (simple_expression
                   (decimal_integer)))))
           (generate_body
-            (generate_direct_block
+            (generate_block
               (for_generate_statement
                 (label_declaration
                   (label))
@@ -119,7 +119,7 @@ end block Gen2;
                       (simple_expression
                         (decimal_integer)))))
                 (generate_body
-                  (generate_direct_block
+                  (generate_block
                     (if_generate_statement
                       (label_declaration
                         (label))
@@ -137,7 +137,7 @@ end block Gen2;
                           (simple_expression
                             (decimal_integer)))
                         (generate_body
-                          (generate_direct_block
+                          (generate_block
                             (component_instantiation_statement
                               (label_declaration
                                 (label))
@@ -216,7 +216,7 @@ end block Gen2;
                 (simple_expression
                   (decimal_integer)))))
           (generate_body
-            (generate_direct_block
+            (generate_block
               (for_generate_statement
                 (label_declaration
                   (label))
@@ -229,7 +229,7 @@ end block Gen2;
                       (simple_expression
                         (decimal_integer)))))
                 (generate_body
-                  (generate_direct_block
+                  (generate_block
                     (if_generate_statement
                       (label_declaration
                         (label))
@@ -247,7 +247,7 @@ end block Gen2;
                           (simple_expression
                             (decimal_integer)))
                         (generate_body
-                          (generate_direct_block
+                          (generate_block
                             (component_instantiation_statement
                               (label_declaration
                                 (label))
@@ -338,7 +338,7 @@ end block Gen2;
                   (name
                     (identifier))))
               (case_generate_body
-                (case_generate_direct_block
+                (generate_block
                   (component_instantiation_statement
                     (label_declaration
                       (label))
@@ -359,7 +359,7 @@ end block Gen2;
                 (label))
               (OTHERS)
               (case_generate_body
-                (case_generate_head
+                (generate_head
                   (signal_declaration
                     (identifier_list
                       (identifier))

--- a/test/corpus/specification_examples/generate.vhd
+++ b/test/corpus/specification_examples/generate.vhd
@@ -1,5 +1,5 @@
 ================================================================================
-Generate statements
+Generate statements, section 11.8
 ================================================================================
 
 Gen: block
@@ -450,6 +450,355 @@ end block Gen2;
                 (label))))
           (end_generate
             (label))))
+      (end_block
+        (label)))))
+
+================================================================================
+Generate statements, section 14.5.3
+================================================================================
+
+-- The following generate statement:
+LABL: for I in 1 to 2 generate
+  signal s1: INTEGER;
+begin
+  s1 <= p1;
+  Inst1: and_gate port map (s1, p2(I), p3);
+end generate LABL;
+
+-- is equivalent to the following two block statements:
+LABL: block
+  constant I: INTEGER := 1;
+  signal s1: INTEGER;
+begin
+  s1 <= p1;
+  Inst1: and_gate port map (s1, p2(I), p3);
+end block LABL;
+
+LABL: block
+  constant I: INTEGER := 2;
+  signal s1: INTEGER;
+begin
+  s1 <= p1;
+  Inst1: and_gate port map (s1, p2(I), p3);
+end block LABL;
+
+-- The following generate statement:
+LABL: if (g1 = g2) generate
+  signal s1: INTEGER;
+begin
+  s1 <= p1;
+  Inst1: and_gate port map (s1, p4, p3);
+end generate LABL;
+
+-- is equivalent to the following statement if g1 = g2;
+-- otherwise, it is equivalent to no statement at all:
+
+LABL: block
+  signal s1: INTEGER;
+begin
+  s1 <= p1;
+  Inst1: and_gate port map (s1, p4, p3);
+end block LABL;
+
+--------------------------------------------------------------------------------
+
+(design_file
+  (line_comment
+    (comment_content))
+  (design_unit
+    (for_generate_statement
+      (label_declaration
+        (label))
+      (for_loop
+        (parameter_specification
+          (identifier)
+          (simple_range
+            (simple_expression
+              (decimal_integer))
+            (simple_expression
+              (decimal_integer)))))
+      (generate_body
+        (generate_head
+          (signal_declaration
+            (identifier_list
+              (identifier))
+            (subtype_indication
+              type: (name
+                (library_type)))))
+        (generate_block
+          (concurrent_simple_signal_assignment
+            (name
+              (identifier))
+            (signal_assignment)
+            (waveform
+              (waveform_element
+                (simple_expression
+                  (name
+                    (identifier))))))
+          (component_instantiation_statement
+            (label_declaration
+              (label))
+            component: (name
+              (identifier))
+            (port_map_aspect
+              (association_list
+                (association_element
+                  (conditional_expression
+                    (simple_expression
+                      (name
+                        (identifier)))))
+                (association_element
+                  (conditional_expression
+                    (simple_expression
+                      (name
+                        (identifier)
+                        (parenthesis_group
+                          (association_or_range_list
+                            (association_element
+                              (conditional_expression
+                                (simple_expression
+                                  (name
+                                    (identifier)))))))))))
+                (association_element
+                  (conditional_expression
+                    (simple_expression
+                      (name
+                        (identifier))))))))))
+      (end_generate
+        (label)))
+    (line_comment
+      (comment_content))
+    (block_statement
+      (label_declaration
+        (label))
+      (block_head
+        (constant_declaration
+          (identifier_list
+            constant: (identifier))
+          (subtype_indication
+            type: (name
+              (library_type)))
+          (initialiser
+            (variable_assignment)
+            (conditional_expression
+              (simple_expression
+                (decimal_integer)))))
+        (signal_declaration
+          (identifier_list
+            (identifier))
+          (subtype_indication
+            type: (name
+              (library_type)))))
+      (concurrent_block
+        (concurrent_simple_signal_assignment
+          (name
+            (identifier))
+          (signal_assignment)
+          (waveform
+            (waveform_element
+              (simple_expression
+                (name
+                  (identifier))))))
+        (component_instantiation_statement
+          (label_declaration
+            (label))
+          component: (name
+            (identifier))
+          (port_map_aspect
+            (association_list
+              (association_element
+                (conditional_expression
+                  (simple_expression
+                    (name
+                      (identifier)))))
+              (association_element
+                (conditional_expression
+                  (simple_expression
+                    (name
+                      (identifier)
+                      (parenthesis_group
+                        (association_or_range_list
+                          (association_element
+                            (conditional_expression
+                              (simple_expression
+                                (name
+                                  (identifier)))))))))))
+              (association_element
+                (conditional_expression
+                  (simple_expression
+                    (name
+                      (identifier)))))))))
+      (end_block
+        (label)))
+    (block_statement
+      (label_declaration
+        (label))
+      (block_head
+        (constant_declaration
+          (identifier_list
+            constant: (identifier))
+          (subtype_indication
+            type: (name
+              (library_type)))
+          (initialiser
+            (variable_assignment)
+            (conditional_expression
+              (simple_expression
+                (decimal_integer)))))
+        (signal_declaration
+          (identifier_list
+            (identifier))
+          (subtype_indication
+            type: (name
+              (library_type)))))
+      (concurrent_block
+        (concurrent_simple_signal_assignment
+          (name
+            (identifier))
+          (signal_assignment)
+          (waveform
+            (waveform_element
+              (simple_expression
+                (name
+                  (identifier))))))
+        (component_instantiation_statement
+          (label_declaration
+            (label))
+          component: (name
+            (identifier))
+          (port_map_aspect
+            (association_list
+              (association_element
+                (conditional_expression
+                  (simple_expression
+                    (name
+                      (identifier)))))
+              (association_element
+                (conditional_expression
+                  (simple_expression
+                    (name
+                      (identifier)
+                      (parenthesis_group
+                        (association_or_range_list
+                          (association_element
+                            (conditional_expression
+                              (simple_expression
+                                (name
+                                  (identifier)))))))))))
+              (association_element
+                (conditional_expression
+                  (simple_expression
+                    (name
+                      (identifier)))))))))
+      (end_block
+        (label)))
+    (line_comment
+      (comment_content))
+    (if_generate_statement
+      (label_declaration
+        (label))
+      (if_generate
+        (simple_expression
+          (parenthesis_expression
+            (element_association_list
+              (element_association
+                (conditional_expression
+                  (relational_expression
+                    (simple_expression
+                      (name
+                        (identifier)))
+                    (relational_operator)
+                    (simple_expression
+                      (name
+                        (identifier)))))))))
+        (generate_body
+          (generate_head
+            (signal_declaration
+              (identifier_list
+                (identifier))
+              (subtype_indication
+                type: (name
+                  (library_type)))))
+          (generate_block
+            (concurrent_simple_signal_assignment
+              (name
+                (identifier))
+              (signal_assignment)
+              (waveform
+                (waveform_element
+                  (simple_expression
+                    (name
+                      (identifier))))))
+            (component_instantiation_statement
+              (label_declaration
+                (label))
+              component: (name
+                (identifier))
+              (port_map_aspect
+                (association_list
+                  (association_element
+                    (conditional_expression
+                      (simple_expression
+                        (name
+                          (identifier)))))
+                  (association_element
+                    (conditional_expression
+                      (simple_expression
+                        (name
+                          (identifier)))))
+                  (association_element
+                    (conditional_expression
+                      (simple_expression
+                        (name
+                          (identifier)))))))))))
+      (end_generate
+        (label)))
+    (line_comment
+      (comment_content))
+    (line_comment
+      (comment_content))
+    (block_statement
+      (label_declaration
+        (label))
+      (block_head
+        (signal_declaration
+          (identifier_list
+            (identifier))
+          (subtype_indication
+            type: (name
+              (library_type)))))
+      (concurrent_block
+        (concurrent_simple_signal_assignment
+          (name
+            (identifier))
+          (signal_assignment)
+          (waveform
+            (waveform_element
+              (simple_expression
+                (name
+                  (identifier))))))
+        (component_instantiation_statement
+          (label_declaration
+            (label))
+          component: (name
+            (identifier))
+          (port_map_aspect
+            (association_list
+              (association_element
+                (conditional_expression
+                  (simple_expression
+                    (name
+                      (identifier)))))
+              (association_element
+                (conditional_expression
+                  (simple_expression
+                    (name
+                      (identifier)))))
+              (association_element
+                (conditional_expression
+                  (simple_expression
+                    (name
+                      (identifier)))))))))
       (end_block
         (label)))))
 


### PR DESCRIPTION
Closes #20 

This fix corrects an interpretation of the standard.  Section 11.8 on its own 
seems to imply that a `begin` inside a `generate` block has to be closed by 
its own `end`, rather that using the `end generate`.  Section 14.5.3 clarifies 
that the first `end` is only required when an "alternative label" is present, 
and optional otherwise.
