### PR TITLE
Fix issue where component instantiation without port map were seen as error

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -858,7 +858,7 @@ export default grammar({
                 seq(repeat1($._process_declarative_item))
             ),
 
-            component_instantiation_statement: $ => prec.dynamic(5, seq(
+            component_instantiation_statement: $ => prec.dynamic(10, seq(
                 $.label_declaration,
                 choice(
                     $.instantiated_unit,           // e.g., entity work.my_ent(arch)
@@ -1031,7 +1031,7 @@ export default grammar({
                 optional($.label_declaration), $.name, ";"
             ),
 
-            concurrent_procedure_call_statement: $ => prec.dynamic(10, seq(
+            concurrent_procedure_call_statement: $ => prec.dynamic(5, seq(
               optional($.label_declaration),
               optional(alias($.POSTPONED, "postponed")),
               $.name, // This name rule ALREADY handles (arg, arg, arg) via function_call selectors

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4502,87 +4502,62 @@
       ]
     },
     "component_instantiation_statement": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "label_declaration"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "instantiated_unit"
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "generic_map_aspect"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "port_map_aspect"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "label_declaration"
-            },
-            {
-              "type": "FIELD",
-              "name": "component",
-              "content": {
+      "type": "PREC_DYNAMIC",
+      "value": 5,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "label_declaration"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
                 "type": "SYMBOL",
-                "name": "name"
-              }
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
+                "name": "instantiated_unit"
+              },
+              {
+                "type": "FIELD",
+                "name": "component",
+                "content": {
                   "type": "SYMBOL",
-                  "name": "generic_map_aspect"
-                },
-                {
-                  "type": "BLANK"
+                  "name": "name"
                 }
-              ]
-            },
-            {
-              "type": "SYMBOL",
-              "name": "port_map_aspect"
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
-        }
-      ]
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "generic_map_aspect"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "port_map_aspect"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": ";"
+          }
+        ]
+      }
     },
     "instantiated_unit": {
       "type": "CHOICE",
@@ -5951,46 +5926,50 @@
       ]
     },
     "concurrent_procedure_call_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "label_declaration"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "ALIAS",
-              "content": {
+      "type": "PREC_DYNAMIC",
+      "value": 10,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
                 "type": "SYMBOL",
-                "name": "POSTPONED"
+                "name": "label_declaration"
               },
-              "named": false,
-              "value": "postponed"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "name"
-        },
-        {
-          "type": "STRING",
-          "value": ";"
-        }
-      ]
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "POSTPONED"
+                },
+                "named": false,
+                "value": "postponed"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "name"
+          },
+          {
+            "type": "STRING",
+            "value": ";"
+          }
+        ]
+      }
     },
     "report_statement": {
       "type": "SEQ",
@@ -12698,6 +12677,10 @@
     ],
     [
       "case_generate_body"
+    ],
+    [
+      "component_instantiation_statement",
+      "concurrent_procedure_call_statement"
     ]
   ],
   "precedences": [],
@@ -13372,6 +13355,5 @@
     }
   ],
   "inline": [],
-  "supertypes": [],
-  "reserved": {}
+  "supertypes": []
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -742,7 +742,6 @@
   {
     "type": "block_comment",
     "named": true,
-    "extra": true,
     "fields": {},
     "children": {
       "multiple": false,
@@ -5142,7 +5141,6 @@
   {
     "type": "line_comment",
     "named": true,
-    "extra": true,
     "fields": {},
     "children": {
       "multiple": false,

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,11 +18,6 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
-typedef struct TSLanguageMetadata {
-  uint8_t major_version;
-  uint8_t minor_version;
-  uint8_t patch_version;
-} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -31,11 +26,10 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
-// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSMapSlice;
+} TSFieldMapSlice;
 
 typedef struct {
   bool visible;
@@ -85,12 +79,6 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
-typedef struct {
-  uint16_t lex_state;
-  uint16_t external_lex_state;
-  uint16_t reserved_word_set_id;
-} TSLexerMode;
-
 typedef union {
   TSParseAction action;
   struct {
@@ -105,7 +93,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t abi_version;
+  uint32_t version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -121,13 +109,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSMapSlice *field_map_slices;
+  const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexerMode *lex_modes;
+  const TSLexMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -141,23 +129,15 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
-  const char *name;
-  const TSSymbol *reserved_words;
-  uint16_t max_reserved_word_set_size;
-  uint32_t supertype_count;
-  const TSSymbol *supertype_symbols;
-  const TSMapSlice *supertype_map_slices;
-  const TSSymbol *supertype_map_entries;
-  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    const TSCharacterRange *range = &ranges[mid_index];
+    TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -165,7 +145,7 @@ static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, in
     }
     size -= half_size;
   }
-  const TSCharacterRange *range = &ranges[index];
+  TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 

--- a/test/corpus/specification_examples/entity.vhd
+++ b/test/corpus/specification_examples/entity.vhd
@@ -443,3 +443,65 @@ end;
                       (name
                         (identifier))))))))))
       (end_entity))))
+
+================================================================================
+An architecutre with an instance with no map
+================================================================================
+
+architecture rtl of my_ent is
+begin
+    my_inst: inst;
+end architecutre;
+
+--------------------------------------------------------------------------------
+(design_file
+  (design_unit
+    (architecture_definition
+      (identifier)
+      (name
+        (identifier))
+      (architecture_head)
+      (concurrent_block
+        (concurrent_procedure_call_statement
+          (label_declaration
+            (label))
+          (name
+            (identifier))))
+      (end_architecture
+        (identifier)))))
+================================================================================
+An architecutre with an instance with only a generic map
+================================================================================
+
+architecture rtl of my_ent is
+begin
+    my_inst: inst
+    generic map (
+        A_GEN => true
+    );
+end architecutre;
+
+--------------------------------------------------------------------------------
+(design_file
+  (design_unit
+    (architecture_definition
+      (identifier)
+      (name
+        (identifier))
+      (architecture_head)
+      (concurrent_block
+        (component_instantiation_statement
+          (label_declaration
+            (label))
+          (name
+            (identifier))
+          (generic_map_aspect
+            (association_list
+              (association_element
+                (name
+                  (identifier))
+                (conditional_expression
+                  (simple_expression
+                    (library_constant_boolean))))))))
+      (end_architecture
+        (identifier)))))

--- a/test/corpus/specification_examples/entity.vhd
+++ b/test/corpus/specification_examples/entity.vhd
@@ -457,18 +457,19 @@ end architecutre;
 (design_file
   (design_unit
     (architecture_definition
-      (identifier)
-      (name
+      architecture: (identifier)
+      entity: (name
         (identifier))
       (architecture_head)
       (concurrent_block
-        (concurrent_procedure_call_statement
+        (component_instantiation_statement
           (label_declaration
             (label))
-          (name
+          component: (name
             (identifier))))
       (end_architecture
-        (identifier)))))
+        architecture: (identifier)))))
+
 ================================================================================
 An architecutre with an instance with only a generic map
 ================================================================================
@@ -482,18 +483,19 @@ begin
 end architecutre;
 
 --------------------------------------------------------------------------------
+
 (design_file
   (design_unit
     (architecture_definition
-      (identifier)
-      (name
+      architecture: (identifier)
+      entity: (name
         (identifier))
       (architecture_head)
       (concurrent_block
         (component_instantiation_statement
           (label_declaration
             (label))
-          (name
+          component: (name
             (identifier))
           (generic_map_aspect
             (association_list
@@ -504,4 +506,40 @@ end architecutre;
                   (simple_expression
                     (library_constant_boolean))))))))
       (end_architecture
-        (identifier)))))
+        architecture: (identifier)))))
+
+================================================================================
+An architecutre with cocurrent procedure calls with a generic map
+================================================================================
+
+architecture rtl of my_ent is
+begin
+    func
+    generic map (
+        A_GEN => true
+    );
+
+    my_label: postponed func2
+    generic map (
+        A_GEN => true
+    );
+
+    func3
+    generic map (
+        A_GEN => true
+    ) (A, B, C);
+
+    postponed func4
+    generic map (
+        A_GEN => true
+    ) (A, B, C);
+
+    my_label: func5
+    generic map (
+        A_GEN => true
+    ) (A, B, C);
+end architecutre;
+
+--------------------------------------------------------------------------------
+
+


### PR DESCRIPTION
… error.

instantiation as follows:
inst_m: my_module
generic map(
    MY_GENERIC => something
);
were seen as error because the grammar was forcing the port map to be present. I changed it so the port map is also optional. However, I had to set precedence on the concurrent_procedural_statement because of conflict. To keep backward compatibility, I made sure the
concurrent_procedural_block was still the one taking priority in case of
    m_label: identifier();
It now parses these things as function call (due to VHDL-2008) which is "fine" because it removes an error node which was my concern.
I also added a test to make sure the generic map only instance is working as intended.