### PR TITLE
Add thread safety

### DIFF
--- a/src/TokenTree.inc
+++ b/src/TokenTree.inc
@@ -1,6 +1,7 @@
 static TypeNode* type_node_new(TokenType type)
 {
     TypeNode* this = ts_malloc(sizeof(TypeNode));
+    if(!this) return 0;
     this->type = type;
     this->next = 0;
     return this;
@@ -26,6 +27,7 @@ static TypeNode* type_node_insert(TypeNode* head, TokenType type)
     }
 
     temp = type_node_new(type);
+    if(!temp) return head;
     temp->next = head;
     return temp;
 }


### PR DESCRIPTION
Hey! We just added VHDL to [Codebook](https://github.com/blopker/codebook), but our tests started failing randomly with segfaults. After some investigation I think I've traced it back to this parser. This PR moves the token_tree data into scanner, while also fixing some existing UB issues.

I also added a few null checks to tighten up the safety a bit, but I'm not sure if any of those actually caused issues in our case.

Let me know if you have any questions!

Best