### PR TITLE
fix: allow severity-level keywords as identifiers

### DIFF
--- a/autogen/core.py
+++ b/autogen/core.py
@@ -119,8 +119,6 @@ def reserved(token_list):
 
 def directives(token_list):
     token_list.append(('protect',          'DIRECTIVE_PROTECT'))
-    token_list.append(('warning',          'DIRECTIVE_WARNING'))
-    token_list.append(('error',            'DIRECTIVE_ERROR'))
 
     token_list.append(('VHDL_VERSION',     'DIRECTIVE_CONSTANT_BUILTIN'))
     token_list.append(('TOOL_TYPE',        'DIRECTIVE_CONSTANT_BUILTIN'))
@@ -133,6 +131,12 @@ def directives(token_list):
     token_list.append(('\n',               'DIRECTIVE_NEWLINE'))
     token_list.append(('\r\n',             'DIRECTIVE_NEWLINE'))
     token_list.append(('\n\r',             'DIRECTIVE_NEWLINE'))
+
+# Called after library registrations so DIRECTIVE_WARNING/ERROR take priority
+# over LIBRARY_CONSTANT_DEBUG when both are valid (e.g. in user_directive context).
+def directive_severity(token_list):
+    token_list.append(('warning',          'DIRECTIVE_WARNING'))
+    token_list.append(('error',            'DIRECTIVE_ERROR'))
 #-------------------------------------------------------------------------------
 
 def delimiters(token_list):

--- a/autogen/gen_token_trie.py
+++ b/autogen/gen_token_trie.py
@@ -26,6 +26,7 @@ ieee.fixed_pkg     .register(token_list)
 ieee.float_pkg     .register(token_list)
 ieee.math_real     .register(token_list)
 ieee.math_complex  .register(token_list)
+core.directive_severity(token_list)
 #-------------------------------------------------------------------------------
 
 class Node:

--- a/grammar.js
+++ b/grammar.js
@@ -201,7 +201,8 @@ export default grammar({
 
     conflicts: $ => [
         [ $.generate_body ],
-        [ $.case_generate_body ]
+        [ $.case_generate_body ],
+        [ $._identifier, $._literal ]
     ],
 
     rules: {
@@ -1225,30 +1226,34 @@ export default grammar({
             )),
 
             _label: $ => choice(
-                alias($.identifier,       $.label),
-                alias($.library_constant, $.label),
-                alias($.library_function, $.label),
-                alias($.library_type,     $.label),
+                alias($.identifier,             $.label),
+                alias($.library_constant,       $.label),
+                alias($.library_constant_debug, $.label),
+                alias($.library_function,       $.label),
+                alias($.library_type,           $.label),
             ),
 
             _attribute: $ => choice(
-                alias($.identifier,       $.attribute_identifier),
-                alias($.library_constant, $.attribute_identifier),
-                alias($.library_function, $.attribute_identifier),
-                alias($.library_type,     $.attribute_identifier),
+                alias($.identifier,             $.attribute_identifier),
+                alias($.library_constant,       $.attribute_identifier),
+                alias($.library_constant_debug, $.attribute_identifier),
+                alias($.library_function,       $.attribute_identifier),
+                alias($.library_type,           $.attribute_identifier),
             ),
 
             _unit: $ => choice(
-                alias($.identifier,       $.unit),
-                alias($.library_constant, $.unit),
-                alias($.library_function, $.unit),
-                alias($.library_type,     $.unit),
+                alias($.identifier,             $.unit),
+                alias($.library_constant,       $.unit),
+                alias($.library_constant_debug, $.unit),
+                alias($.library_function,       $.unit),
+                alias($.library_type,           $.unit),
                 $.library_constant_unit
             ),
 
             _identifier: $ => choice(
                 $.identifier,
                 $.library_constant,
+                alias($.library_constant_debug, $.identifier),
                 $.library_function,
                 $.library_type,
             ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7527,6 +7527,15 @@
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
+            "name": "library_constant_debug"
+          },
+          "named": true,
+          "value": "label"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
             "name": "library_function"
           },
           "named": true,
@@ -7560,6 +7569,15 @@
           "content": {
             "type": "SYMBOL",
             "name": "library_constant"
+          },
+          "named": true,
+          "value": "attribute_identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "library_constant_debug"
           },
           "named": true,
           "value": "attribute_identifier"
@@ -7609,6 +7627,15 @@
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
+            "name": "library_constant_debug"
+          },
+          "named": true,
+          "value": "unit"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
             "name": "library_function"
           },
           "named": true,
@@ -7639,6 +7666,15 @@
         {
           "type": "SYMBOL",
           "name": "library_constant"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "library_constant_debug"
+          },
+          "named": true,
+          "value": "identifier"
         },
         {
           "type": "SYMBOL",
@@ -12698,6 +12734,10 @@
     ],
     [
       "case_generate_body"
+    ],
+    [
+      "_identifier",
+      "_literal"
     ]
   ],
   "precedences": [],

--- a/src/token_tree_match.inc
+++ b/src/token_tree_match.inc
@@ -5512,38 +5512,6 @@ switch(lookahead){
             break;
         }
         break;
-      case 'r':
-        lookahead = advance(lexer);
-        type = 0;
-        switch(lookahead){
-          case 'r':
-            lookahead = advance(lexer);
-            type = 0;
-            switch(lookahead){
-              case 'o':
-                lookahead = advance(lexer);
-                type = 0;
-                switch(lookahead){
-                  case 'r':
-                    lookahead = advance(lexer);
-                    lexer->mark_end(lexer);
-                    {
-                      static const TokenType type_array[] = { LIBRARY_CONSTANT_DEBUG, DIRECTIVE_ERROR, 0 };
-                      type = type_array;
-                    }
-                    break;
-                  default:
-                    break;
-                }
-                break;
-              default:
-                break;
-            }
-            break;
-          default:
-            break;
-        }
-        break;
       case 'v':
         lookahead = advance(lexer);
         type = 0;
@@ -5666,6 +5634,38 @@ switch(lookahead){
             {
               static const TokenType type_array[] = { LIBRARY_CONSTANT_CHARACTER, 0 };
               type = type_array;
+            }
+            break;
+          default:
+            break;
+        }
+        break;
+      case 'r':
+        lookahead = advance(lexer);
+        type = 0;
+        switch(lookahead){
+          case 'r':
+            lookahead = advance(lexer);
+            type = 0;
+            switch(lookahead){
+              case 'o':
+                lookahead = advance(lexer);
+                type = 0;
+                switch(lookahead){
+                  case 'r':
+                    lookahead = advance(lexer);
+                    lexer->mark_end(lexer);
+                    {
+                      static const TokenType type_array[] = { DIRECTIVE_ERROR, LIBRARY_CONSTANT_DEBUG, 0 };
+                      type = type_array;
+                    }
+                    break;
+                  default:
+                    break;
+                }
+                break;
+              default:
+                break;
             }
             break;
           default:
@@ -24304,7 +24304,7 @@ switch(lookahead){
                             lookahead = advance(lexer);
                             lexer->mark_end(lexer);
                             {
-                              static const TokenType type_array[] = { LIBRARY_CONSTANT_DEBUG, DIRECTIVE_WARNING, 0 };
+                              static const TokenType type_array[] = { DIRECTIVE_WARNING, LIBRARY_CONSTANT_DEBUG, 0 };
                               type = type_array;
                             }
                             break;

--- a/test/corpus/library_constant_debug_as_identifier.vhd
+++ b/test/corpus/library_constant_debug_as_identifier.vhd
@@ -1,0 +1,149 @@
+================================================================================
+Severity-level keywords used as signal names (_identifier rule)
+================================================================================
+
+architecture Behaviour of MyModule is
+  signal error   : std_logic;
+  signal warning : std_logic;
+  signal note    : std_logic;
+  signal failure : std_logic;
+begin
+end Behaviour;
+
+--------------------------------------------------------------------------------
+
+(design_file
+  (design_unit
+    (architecture_definition
+      architecture: (identifier)
+      entity: (name
+        (identifier))
+      (architecture_head
+        (signal_declaration
+          (identifier_list
+            (identifier))
+          (subtype_indication
+            type: (name
+              (library_type))))
+        (signal_declaration
+          (identifier_list
+            (identifier))
+          (subtype_indication
+            type: (name
+              (library_type))))
+        (signal_declaration
+          (identifier_list
+            (identifier))
+          (subtype_indication
+            type: (name
+              (library_type))))
+        (signal_declaration
+          (identifier_list
+            (identifier))
+          (subtype_indication
+            type: (name
+              (library_type)))))
+      (concurrent_block)
+      (end_architecture
+        architecture: (identifier)))))
+
+================================================================================
+Severity-level keyword used as a process label (_label rule)
+================================================================================
+
+architecture Behaviour of MyModule is
+begin
+  error : process is
+  begin
+  end process error;
+end Behaviour;
+
+--------------------------------------------------------------------------------
+
+(design_file
+  (design_unit
+    (architecture_definition
+      architecture: (identifier)
+      entity: (name
+        (identifier))
+      (architecture_head)
+      (concurrent_block
+        (process_statement
+          (label_declaration
+            (label))
+          (process_head)
+          (sequential_block)
+          (end_process
+            (label))))
+      (end_architecture
+        architecture: (identifier)))))
+
+================================================================================
+Severity-level keyword used as an attribute name (_attribute rule)
+================================================================================
+
+architecture Behaviour of MyModule is
+  attribute error : string;
+begin
+end Behaviour;
+
+--------------------------------------------------------------------------------
+
+(design_file
+  (design_unit
+    (architecture_definition
+      architecture: (identifier)
+      entity: (name
+        (identifier))
+      (architecture_head
+        (attribute_declaration
+          attribute: (identifier)
+          type: (name
+            (library_type))))
+      (concurrent_block)
+      (end_architecture
+        architecture: (identifier)))))
+
+================================================================================
+Severity-level keyword used as a port map formal (_identifier rule)
+================================================================================
+
+architecture Behaviour of MyModule is
+begin
+  u1 : MyComp port map (error => sig_a, warning => sig_b);
+end Behaviour;
+
+--------------------------------------------------------------------------------
+
+(design_file
+  (design_unit
+    (architecture_definition
+      architecture: (identifier)
+      entity: (name
+        (identifier))
+      (architecture_head)
+      (concurrent_block
+        (component_instantiation_statement
+          (label_declaration
+            (label))
+          component: (name
+            (identifier))
+          (port_map_aspect
+            (association_list
+              (association_element
+                (name
+                  (identifier))
+                (conditional_expression
+                  (simple_expression
+                    (name
+                      (identifier)))))
+              (association_element
+                (name
+                  (identifier))
+                (conditional_expression
+                  (simple_expression
+                    (name
+                      (identifier)))))))))
+      (end_architecture
+        architecture: (identifier)))))
+


### PR DESCRIPTION
error, warning, note and failure are tokenized as
LIBRARY_CONSTANT_DEBUG
  by the external scanner. They were missing from the _identifier,
_label,
  _attribute and _unit grammar rules, causing parse errors when used as
  signal names, labels, attribute names, etc.

  Two changes fix this:

  1. Add $.library_constant_debug to _identifier, _label, _attribute and _unit in grammar.js, and add the [ $._identifier, $._literal ] GLR conflict that becomes necessary because library_constant_debug now appears in both rules.

  2. Move register_directives() to after all library registrations. The token tree uses prepend insertion, so the last registration wins. With directives registered last, DIRECTIVE_ERROR /
     DIRECTIVE_WARNING take priority over LIBRARY_CONSTANT_DEBUG when both
     are valid (i.e. in tool-directive context), preserving correct behaviour for `error and `warning directives.

  The only parse-tree change is that severity-level keywords in
identifier
  positions now produce library_constant_debug nodes instead of ERROR
nodes.