### PR TITLE
Indents query

### DIFF
--- a/queries/Neovim/indents.scm
+++ b/queries/Neovim/indents.scm
@@ -1,0 +1,26 @@
+[
+  (entity_declaration)
+  (architecture_definition)
+  (process_statement)
+  (if_statement_block)
+  (case_statement)
+  (case_statement_alternative)
+  (loop_statement)
+  (port_clause)
+  (generic_clause)
+] @indent.begin
+
+[
+  "begin"
+  "elsif"
+  "else"
+  (end_entity)
+  (end_architecture)
+  (end_process)
+  (end_if)
+  (end_case)
+  (end_loop)
+] @indent.branch
+
+(port_clause ")" @indent.branch)
+(generic_clause ")" @indent.branch)

--- a/queries/Neovim/indents.scm
+++ b/queries/Neovim/indents.scm
@@ -1,13 +1,54 @@
+;-------------------------------------------------------------------------------
+;
+; Maintainer: jgonmor16, jpt13653903
+; Feature Reference: https://github.com/nvim-treesitter/nvim-treesitter?tab=readme-ov-file#indentation
+;-------------------------------------------------------------------------------
+;
+; Indentation anchors on the outermost wrapper node of each construct, not
+; on its individual clauses.  Clause nodes such as elsif_statement nest
+; recursively, so anchoring on them adds one indent level per clause; the
+; wrapper node appears exactly once per construct regardless of how deeply
+; its clauses nest.  This also keeps the query correct if the if/elsif/else
+; nesting is ever flattened.
+;
+; Head and body nodes (entity_head, concurrent_block, sequential_block, ...)
+; are deliberately not captured.  Anchoring on the wrapper covers both the
+; declarative and the statement region with a single capture, and "begin"
+; branches back to the wrapper's own level.  process_head and generate_body
+; each have an optional-"is"/optional-"begin" form whose node starts on a
+; different line in each case, so neither can be anchored directly.
+
 [
+  ; Design units
   (entity_declaration)
   (architecture_definition)
+  (package_declaration)
+  (package_definition)
+  (component_declaration)
+
+  ; Interface and association lists
+  (port_clause)
+  (generic_clause)
+  (association_list)
+
+  ; Concurrent statements
   (process_statement)
+  (block_statement)
+  (component_instantiation_statement)
+  (for_generate_statement)
+  (if_generate_statement)
+  (case_generate_statement)
+  (case_generate_alternative)
+
+  ; Sequential statements
   (if_statement_block)
   (case_statement)
   (case_statement_alternative)
   (loop_statement)
-  (port_clause)
-  (generic_clause)
+
+  ; Subprogram and types
+  (subprogram_definition)
+  (record_type_definition)
 ] @indent.begin
 
 [
@@ -16,11 +57,24 @@
   "else"
   (end_entity)
   (end_architecture)
+  (end_package)
+  (end_package_body)
+  (end_component)
   (end_process)
+  (end_block)
+  (end_generate)
   (end_if)
   (end_case)
   (end_loop)
+  (end_record)
+  (subprogram_end)
 ] @indent.branch
 
-(port_clause ")" @indent.branch)
-(generic_clause ")" @indent.branch)
+(port_clause
+  ")" @indent.branch)
+
+(generic_clause
+  ")" @indent.branch)
+
+(association_list
+  ")" @indent.branch)

--- a/test/indent/block_statement.vhd
+++ b/test/indent/block_statement.vhd
@@ -1,0 +1,21 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity block_statement is
+  port (
+    d : in  std_logic;
+    q : out std_logic
+  );
+end entity;
+
+architecture rtl of block_statement is
+begin
+
+  b_wrap : block
+    signal t : std_logic;
+  begin
+    t <= d;
+    q <= t;
+  end block;
+
+end architecture;

--- a/test/indent/case_generate.vhd
+++ b/test/indent/case_generate.vhd
@@ -1,0 +1,26 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity case_generate is
+  generic (
+    MODE : natural := 0
+  );
+  port (
+    d : in  std_logic_vector(7 downto 0);
+    q : out std_logic_vector(7 downto 0)
+  );
+end entity;
+
+architecture rtl of case_generate is
+begin
+
+  g_mode : case MODE generate
+    when 0 =>
+      q <= d;
+    when 1 =>
+      q <= not d;
+    when others =>
+      q <= (others => '0');
+  end generate;
+
+end architecture;

--- a/test/indent/case_statement.vhd
+++ b/test/indent/case_statement.vhd
@@ -1,0 +1,29 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity case_statement is
+  port (
+    clk : in  std_logic;
+    sel : in  std_logic_vector(1 downto 0);
+    q   : out std_logic
+  );
+end entity;
+
+architecture rtl of case_statement is
+begin
+
+  process (clk)
+  begin
+    if rising_edge(clk) then
+      case sel is
+        when "00" =>
+          q <= '0';
+        when "01" =>
+          q <= '1';
+        when others =>
+          q <= 'Z';
+      end case;
+    end if;
+  end process;
+
+end architecture;

--- a/test/indent/component_instantiation.vhd
+++ b/test/indent/component_instantiation.vhd
@@ -1,0 +1,34 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity component_instantiation is
+  port (
+    clk : in  std_logic;
+    q   : out std_logic
+  );
+end entity;
+
+architecture struct of component_instantiation is
+
+  component child is
+    generic (
+      WIDTH : positive := 8
+    );
+    port (
+      clk : in  std_logic;
+      q   : out std_logic
+    );
+  end component;
+
+begin
+
+  u_child : child
+    generic map (
+      WIDTH => 4
+    )
+    port map (
+      clk => clk,
+      q   => q
+    );
+
+end architecture;

--- a/test/indent/for_generate.vhd
+++ b/test/indent/for_generate.vhd
@@ -1,0 +1,31 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity for_generate is
+  generic (
+    WIDTH : positive := 8
+  );
+  port (
+    d  : in  std_logic_vector(WIDTH - 1 downto 0);
+    q1 : out std_logic_vector(WIDTH - 1 downto 0);
+    q2 : out std_logic_vector(WIDTH - 1 downto 0)
+  );
+end entity;
+
+architecture rtl of for_generate is
+  signal buf : std_logic_vector(WIDTH - 1 downto 0);
+begin
+
+  g_simple : for i in 0 to WIDTH - 1 generate
+    buf(i) <= d(i);
+    q1(i) <= buf(i);
+  end generate;
+
+  g_declarative : for i in 0 to WIDTH - 1 generate
+    signal t : std_logic;
+  begin
+    t <= buf(i);
+    q2(i) <= t;
+  end generate;
+
+end architecture;

--- a/test/indent/if_generate.vhd
+++ b/test/indent/if_generate.vhd
@@ -1,0 +1,25 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity if_generate is
+  generic (
+    MODE : natural := 0
+  );
+  port (
+    d : in  std_logic_vector(7 downto 0);
+    q : out std_logic_vector(7 downto 0)
+  );
+end entity;
+
+architecture rtl of if_generate is
+begin
+
+  g_mode : if MODE = 0 generate
+    q <= d;
+  elsif MODE = 1 generate
+    q <= not d;
+  else generate
+    q <= (others => '0');
+  end generate;
+
+end architecture;

--- a/test/indent/if_statement.vhd
+++ b/test/indent/if_statement.vhd
@@ -1,0 +1,29 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity if_statement is
+  port (
+    clk : in  std_logic;
+    a   : in  std_logic;
+    b   : in  std_logic;
+    q   : out std_logic
+  );
+end entity;
+
+architecture rtl of if_statement is
+begin
+
+  process (clk)
+  begin
+    if rising_edge(clk) then
+      if a = '1' then
+        q <= '0';
+      elsif b = '1' then
+        q <= '1';
+      else
+        q <= 'Z';
+      end if;
+    end if;
+  end process;
+
+end architecture;

--- a/test/indent/init.lua
+++ b/test/indent/init.lua
@@ -1,0 +1,45 @@
+--------------------------------------------------------------------------------
+--
+-- Minimal Neovim configuration for the indent tests.
+--
+-- Loads the parser and queries staged by run.sh rather than anything from
+-- the user's own configuration, so the result does not depend on what the
+-- person running the tests happens to have installed.
+--
+--------------------------------------------------------------------------------
+
+local work = assert(vim.env.NVIM_TS_WORK, "NVIM_TS_WORK is not set")
+local plugin = assert(vim.env.NVIM_TS_PLUGIN, "NVIM_TS_PLUGIN is not set")
+
+vim.opt.runtimepath:prepend(work)
+vim.opt.runtimepath:prepend(plugin)
+
+vim.treesitter.language.add("vhdl", { path = work .. "/parser/vhdl.so" })
+
+vim.opt.shiftwidth = 2
+vim.opt.tabstop = 2
+vim.opt.expandtab = true
+
+vim.cmd("filetype on")
+
+vim.api.nvim_create_autocmd("FileType", {
+    pattern = "vhdl",
+    callback = function()
+        vim.bo.shiftwidth = 2
+        vim.bo.expandtab = true
+        vim.treesitter.start()
+        vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+    end,
+})
+
+-- Abort the query if the indent queries are not what is being measured.
+function _G.indent_test_guard()
+    local query = vim.api.nvim_get_runtime_file("queries/vhdl/indents.scm", false)[1]
+    local expr = vim.bo.indentexpr
+
+    if not query or not expr:find("nvim%-treesitter") then
+        io.stderr:write(("setup check failed: indents.scm=%s indentexpr=%s\n")
+            :format(tostring(query), tostring(expr)))
+        vim.cmd("cquit 3")
+    end
+end

--- a/test/indent/interface_list.vhd
+++ b/test/indent/interface_list.vhd
@@ -1,0 +1,19 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity interface_list is
+  generic (
+    WIDTH : positive := 8;
+    DEPTH : positive := 4
+  );
+  port (
+    clk : in  std_logic;
+    d   : in  std_logic_vector(WIDTH - 1 downto 0);
+    q   : out std_logic_vector(WIDTH - 1 downto 0)
+  );
+end entity;
+
+architecture rtl of interface_list is
+begin
+  q <= d;
+end architecture;

--- a/test/indent/loop_statement.vhd
+++ b/test/indent/loop_statement.vhd
@@ -1,0 +1,33 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity loop_statement is
+  port (
+    clk : in  std_logic;
+    d   : in  std_logic_vector(7 downto 0);
+    q   : out std_logic_vector(7 downto 0)
+  );
+end entity;
+
+architecture rtl of loop_statement is
+begin
+
+  process (clk)
+    variable n : natural;
+  begin
+    if rising_edge(clk) then
+      for i in 0 to 7 loop
+        if d(i) = '1' then
+          q(i) <= '1';
+        else
+          q(i) <= '0';
+        end if;
+      end loop;
+      n := 0;
+      while n < 8 loop
+        n := n + 1;
+      end loop;
+    end if;
+  end process;
+
+end architecture;

--- a/test/indent/package.vhd
+++ b/test/indent/package.vhd
@@ -1,0 +1,26 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+package indent_pkg is
+
+  constant WIDTH : positive := 8;
+
+  function is_set (v : std_logic) return boolean;
+
+  procedure clear (signal s : out std_logic);
+
+end package;
+
+package body indent_pkg is
+
+  function is_set (v : std_logic) return boolean is
+  begin
+    return v = '1';
+  end function;
+
+  procedure clear (signal s : out std_logic) is
+  begin
+    s <= '0';
+  end procedure;
+
+end package body;

--- a/test/indent/process_statement.vhd
+++ b/test/indent/process_statement.vhd
@@ -1,0 +1,34 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity process_statement is
+  port (
+    clk : in  std_logic;
+    d   : in  std_logic;
+    q   : out std_logic
+  );
+end entity;
+
+architecture rtl of process_statement is
+  signal level : std_logic;
+begin
+
+  p_with_is : process (clk) is
+    variable v : std_logic;
+  begin
+    if rising_edge(clk) then
+      v := d;
+      level <= v;
+    end if;
+  end process;
+
+  p_no_is : process (clk)
+    variable w : std_logic;
+  begin
+    if rising_edge(clk) then
+      w := level;
+      q <= w;
+    end if;
+  end process;
+
+end architecture;

--- a/test/indent/record_type.vhd
+++ b/test/indent/record_type.vhd
@@ -1,0 +1,17 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+package record_type_pkg is
+
+  type axis_t is record
+    tdata  : std_logic_vector(7 downto 0);
+    tvalid : std_logic;
+    tready : std_logic;
+  end record;
+
+  type control_t is record
+    enable : std_logic;
+    mode   : natural;
+  end record;
+
+end package;

--- a/test/indent/run.sh
+++ b/test/indent/run.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+#-------------------------------------------------------------------------------
+#
+# Check that the Neovim indent queries reproduce the reference files.
+#
+# Each file in test/indent/ is already indented the way the queries are
+# meant to indent it, so re-indenting with gg=G must leave it unchanged.
+# Any diff is a failure.
+#
+# This cannot run under the parser test CI: Neovim's tree-sitter indent
+# support lives in the nvim-treesitter plugin, not in the tree-sitter CLI,
+# so the plugin has to be on disk.  Point NVIM_TREESITTER at a checkout.
+#
+#   NVIM_TREESITTER=~/.local/share/nvim/site/pack/core/opt/nvim-treesitter \
+#     ./test/indent/run.sh
+#
+#-------------------------------------------------------------------------------
+
+set -eu
+
+repo=$(cd "$(dirname "$0")/../.." && pwd)
+
+if [ -z "${NVIM_TREESITTER:-}" ]; then
+    echo "NVIM_TREESITTER is not set; see the comment at the top of this script." >&2
+    exit 2
+fi
+
+if [ ! -d "$NVIM_TREESITTER" ]; then
+    echo "NVIM_TREESITTER does not exist: $NVIM_TREESITTER" >&2
+    exit 2
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+mkdir -p "$work/parser" "$work/queries/vhdl"
+
+# Build the parser from this working tree, not from a release, so the test
+# exercises whatever the grammar currently is.
+tree-sitter build -o "$work/parser/vhdl.so" 2>/dev/null
+
+# Neovim looks for queries under queries/<language>/ on the runtimepath,
+# whereas this repository groups them by editor.
+cp "$repo"/queries/Neovim/*.scm "$work/queries/vhdl/"
+
+status=0
+
+for ref in "$repo"/test/indent/*.vhd; do
+    name=$(basename "$ref")
+    got="$work/$name"
+
+    NVIM_TS_WORK="$work" \
+    NVIM_TS_PLUGIN="$NVIM_TREESITTER" \
+        nvim --headless -i NONE -u "$repo/test/indent/init.lua" "$ref" \
+        -c "lua indent_test_guard()" \
+        -c 'silent normal! gg=G' \
+        -c "silent write! $got" \
+        -c 'quit!'
+
+    if diff -u "$ref" "$got" > "$work/$name.diff"; then
+        echo "ok    $name"
+    else
+        echo "FAIL  $name"
+        cat "$work/$name.diff"
+        status=1
+    fi
+done
+
+exit $status

--- a/test/indent/subprogram.vhd
+++ b/test/indent/subprogram.vhd
@@ -1,0 +1,40 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity subprogram is
+  port (
+    clk : in  std_logic;
+    q   : out std_logic
+  );
+end entity;
+
+architecture rtl of subprogram is
+
+  function parity (v : std_logic_vector) return std_logic is
+    variable acc : std_logic := '0';
+  begin
+    for i in v'range loop
+      acc := acc xor v(i);
+    end loop;
+    return acc;
+  end function;
+
+  procedure pulse (signal s : out std_logic) is
+  begin
+    s <= '1';
+  end procedure;
+
+  signal level : std_logic;
+
+begin
+
+  process (clk)
+  begin
+    if rising_edge(clk) then
+      level <= parity("10100110");
+    end if;
+  end process;
+
+  q <= level;
+
+end architecture;


### PR DESCRIPTION
Adds `queries/Neovim/indents.scm`, with reference files and a runner under
`test/indent/`. Follows on from the nvim-treesitter discussion where you said
a PR here would be welcome.

## Why

`queries/Neovim/` has highlights, folds, injections and textobjects but no
indents query, so Neovim falls back to its bundled `runtime/indent/vhdl.vim`
— Gerald Lai's script, which declares itself as '93 syntax and has had no
substantive change since 2017.

## Design

Indentation anchors on the outermost wrapper node of each construct rather
than on its individual clauses.

This is directly relevant to the flattening you mentioned. Because the anchor
is `if_statement_block`, which appears exactly once per chain no matter how
many `elsif` clauses nest inside it, the query gives identical results under
either tree shape — flattening `if/elsif/else` will not require changes here.
Anchoring on `elsif_statement` would have: each clause is an ancestor
starting on a different row, so `is_processed_by_row` in nvim-treesitter's
`indent.lua` does not deduplicate them and the indent compounds one level per
clause. I measured that before choosing the current approach.

Head and body nodes (`entity_head`, `concurrent_block`, `sequential_block`,
`process_head`, `generate_body`) are deliberately not captured. The wrapper
covers both the declarative and statement regions with one capture, and
`"begin"` branches back to the construct's own level. `process_head` and
`generate_body` each have an optional-keyword variant whose node starts on a
different line in each form, so neither can be anchored directly.

## Tests

Thirteen reference files under `test/indent/`, one per construct family, each
already indented the way the query should indent it. Re-indenting must
therefore be a no-op, so the check is a diff against the input and there are
no expected-output files to keep in step.

    NVIM_TREESITTER=/path/to/nvim-treesitter ./test/indent/run.sh

This cannot run under the parser test CI: the tree-sitter indent
implementation lives in the nvim-treesitter plugin, not in the tree-sitter
CLI, so the plugin has to be on disk. The runner builds the parser from the
working tree and stages `queries/Neovim/` as `queries/vhdl/` on the
runtimepath. It exits 3 if it detects it is not measuring the queries —
without that check a misconfigured run still produces a full set of
plausible-looking diffs.

## Not covered

- Multi-line aggregates, and continuation lines of concurrent assignments
- The hanging paren style; this imposes the block style on interface lists
- `configuration` and `context` declarations, protected types, `with ... select`

Happy to add any of those, or to drop the runner if you would rather not
carry a Neovim dependency under `test/`. I have listed myself in the query
header alongside you, as you suggested.